### PR TITLE
fix: Windows docker backend + docker/k8s 功能補完

### DIFF
--- a/packages/agent/src/docker.ts
+++ b/packages/agent/src/docker.ts
@@ -3,7 +3,9 @@ import path from "node:path";
 import { PassThrough } from "node:stream";
 import Docker from "dockerode";
 import type { InstanceStatus, InstanceStats, WorldSettings } from "@palserver/shared";
+import { buildLaunchArgs } from "@palserver/shared";
 import { CONTAINER_PREFIX, IMAGES, INSTANCE_LABEL } from "./env.js";
+import { mergeEnginePatch } from "./engine-ini-merge.js";
 import type { InstanceRecord } from "./store.js";
 import { renderPalWorldSettingsIni } from "./settings-ini.js";
 
@@ -56,6 +58,17 @@ export function writeConfig(instanceDir: string, settings: WorldSettings): void 
   );
 }
 
+/** Re-apply managed Engine.ini tweaks into the bind-mounted saved dir before
+ *  container start. The server resets Engine.ini on shutdown; like native's
+ *  writeIni(), we re-apply from the store on every start. */
+function applyEngineIniDocker(rec: InstanceRecord, instanceDir: string): void {
+  if (!rec.engineSettings || Object.keys(rec.engineSettings).length === 0) return;
+  const file = path.join(instanceDir, "saved", "Config", "LinuxServer", "Engine.ini");
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const existing = fs.existsSync(file) ? fs.readFileSync(file, "utf8") : "";
+  fs.writeFileSync(file, mergeEnginePatch(existing, rec.engineSettings));
+}
+
 export async function createContainer(
   rec: InstanceRecord,
   instanceDir: string,
@@ -66,13 +79,21 @@ export async function createContainer(
   const bindings: Record<string, { HostPort: string }[]> = {
     "8211/udp": [{ HostPort: String(rec.gamePort) }],
   };
+  if (rec.queryPort) {
+    ports[`${rec.queryPort}/udp`] = {};
+    bindings[`${rec.queryPort}/udp`] = [{ HostPort: String(rec.queryPort) }];
+  }
   if (rec.settings.RESTAPIEnabled) {
     ports["8212/tcp"] = {};
-    // REST API stays loopback-only: it is the agent's private control channel.
     bindings["8212/tcp"] = [{ HostPort: "0" }];
   }
 
-  // 自訂鏡像優先(沿用已部署的其他帕魯鏡像);否則用內建 vanilla/modded 映像。
+  const launchArgs = [
+    `-port=${rec.gamePort}`,
+    ...(rec.queryPort ? [`-queryport=${rec.queryPort}`] : []),
+    ...buildLaunchArgs(rec.launchOptions),
+  ];
+
   const image = rec.dockerImage?.trim() || IMAGES[rec.flavor];
   const imageExists = await docker
     .getImage(image)
@@ -95,6 +116,7 @@ export async function createContainer(
     Image: image,
     Labels: { [INSTANCE_LABEL]: rec.id },
     ExposedPorts: ports,
+    Cmd: launchArgs,
     HostConfig: {
       PortBindings: bindings,
       Binds: [
@@ -109,6 +131,7 @@ export async function createContainer(
 
 export async function startInstance(rec: InstanceRecord, instanceDir: string): Promise<void> {
   writeConfig(instanceDir, rec.settings);
+  applyEngineIniDocker(rec, instanceDir);
   let container = await findContainer(rec);
   if (!container) {
     await createContainer(rec, instanceDir);
@@ -227,6 +250,31 @@ export async function listInContainer(
   dirPath: string,
 ): Promise<string> {
   return execInContainer(rec, ["ls", "-1", dirPath]).then((s) => s.trim());
+}
+
+/** Resolve the ephemeral host port Docker assigned for the REST API (8212/tcp). */
+export async function restHostPort(rec: InstanceRecord): Promise<number | null> {
+  const container = await findContainer(rec);
+  if (!container) return null;
+  const info = await container.inspect();
+  const binding = info.NetworkSettings.Ports["8212/tcp"];
+  return binding?.[0]?.HostPort ? Number(binding[0].HostPort) : null;
+}
+
+/** Pull latest image and recreate container. */
+export async function updateImage(rec: InstanceRecord, instanceDir: string): Promise<string> {
+  const image = rec.dockerImage?.trim() || IMAGES[rec.flavor];
+  const stream = await docker.pull(image);
+  await new Promise<void>((resolve, reject) => {
+    docker.modem.followProgress(stream, (err: Error | null) => (err ? reject(err) : resolve()));
+  });
+  const container = await findContainer(rec);
+  if (container) {
+    await container.stop({ t: 30 }).catch(() => {});
+    await container.remove({ force: true });
+  }
+  await startInstance(rec, instanceDir);
+  return image;
 }
 
 export const dockerDriver: ServerDriver = {

--- a/packages/agent/src/k8s-env-patch.ts
+++ b/packages/agent/src/k8s-env-patch.ts
@@ -1,5 +1,6 @@
 import * as k8s from "@kubernetes/client-node";
-import type { WorldSettings } from "@palserver/shared";
+import type { LaunchOptions, WorldSettings } from "@palserver/shared";
+import { buildLaunchEnv } from "@palserver/shared";
 import type { InstanceRecord } from "./store.js";
 import { loadKubeConfig } from "./k8s.js";
 import { INI_TO_ENV, settingsToEnvPatch } from "./env-mapping.js";
@@ -115,4 +116,40 @@ export async function applyEnvPatchK8s(
   }
 
   return { unsupported, applied };
+}
+
+/** Apply launchOptions + queryPort as env vars on the StatefulSet. */
+export async function applyLaunchOptionsK8s(
+  rec: InstanceRecord,
+  launchOptions: LaunchOptions | undefined,
+  queryPort?: number,
+): Promise<string[]> {
+  const envPatch = buildLaunchEnv(launchOptions, queryPort);
+  if (Object.keys(envPatch).length === 0) return [];
+  const kc = loadKubeConfig();
+  const appsApi = kc.makeApiClient(k8s.AppsV1Api);
+  const sts = await appsApi.readNamespacedStatefulSet({ name: rec.k8sStatefulSet!, namespace: rec.k8sNamespace! });
+  const containers = sts.spec?.template?.spec?.containers ?? [];
+  const containerIndex = Math.max(0, containers.findIndex((item) => item.name === "palworld-server"));
+  const container = containers[containerIndex];
+  if (!container) throw new Error("找不到 game-server 容器定義");
+  const existingEnv = (container.env ?? []).map((e) => ({ ...e }));
+  const applied: string[] = [];
+  for (const [envName, envValue] of Object.entries(envPatch)) {
+    const idx = existingEnv.findIndex((e) => e.name === envName);
+    if (idx >= 0) {
+      if (existingEnv[idx].valueFrom) continue;
+      existingEnv[idx] = { ...existingEnv[idx], name: envName, value: envValue };
+    } else {
+      existingEnv.push({ name: envName, value: envValue });
+    }
+    applied.push(envName);
+  }
+  if (applied.length === 0) return [];
+  const jsonPatch = [{ op: container.env ? "replace" : "add", path: `/spec/template/spec/containers/${containerIndex}/env`, value: existingEnv }];
+  await appsApi.patchNamespacedStatefulSet(
+    { name: rec.k8sStatefulSet!, namespace: rec.k8sNamespace!, body: jsonPatch },
+    { middleware: [jsonPatchMiddleware()] } as unknown as k8s.Configuration,
+  );
+  return applied;
 }

--- a/packages/agent/src/k8s.ts
+++ b/packages/agent/src/k8s.ts
@@ -3,7 +3,8 @@ import { PassThrough } from "node:stream";
 import type { InstanceStats, InstanceStatus, LogSource, LogSourceId } from "@palserver/shared";
 import type { ServerDriver, DriverContext } from "./driver.js";
 import type { InstanceRecord } from "./store.js";
-import { execInPod, findPodName, loadKubeConfig } from "./k8s-files.js";
+import { execInPod, findPodName, loadKubeConfig, readFileInPod, writeFileInPod } from "./k8s-files.js";
+import { mergeEnginePatch } from "./engine-ini-merge.js";
 
 /**
  * k8s backend driver.
@@ -89,6 +90,10 @@ export const k8sDriver: ServerDriver = {
       { name: statefulSet, namespace, body: patch },
       { middleware: [strategicMergeMiddleware()] } as unknown as k8s.Configuration,
     );
+    if (rec.engineSettings && Object.keys(rec.engineSettings).length > 0) {
+      await new Promise((r) => setTimeout(r, 3000));
+      await applyEngineIniK8s(rec).catch(() => {});
+    }
   },
 
   async stop(rec, _ctx): Promise<void> {
@@ -310,6 +315,34 @@ export function computeCpuPercent(
   const wallMicros = (atMs - previous.atMs) * 1000;
   if (wallMicros <= 0) return null;
   return Math.max(0, (usageMicros - previous.usageMicros) / wallMicros * 100);
+}
+
+const K8S_ENGINE_INI = "Pal/Saved/Config/LinuxServer/Engine.ini";
+
+/** Re-apply managed Engine.ini into the running Pod, then kill PID 1 to restart. */
+export async function applyEngineIniK8s(rec: InstanceRecord): Promise<void> {
+  if (!rec.engineSettings || Object.keys(rec.engineSettings).length === 0) return;
+  const kc = loadKubeConfig();
+  const coreApi = kc.makeApiClient(k8s.CoreV1Api);
+  const podName = await findPodName(coreApi, rec.k8sNamespace!, rec.k8sStatefulSet!).catch(() => null);
+  if (!podName) return;
+  const existing = await readFileInPod(rec, K8S_ENGINE_INI).catch(() => "");
+  const merged = mergeEnginePatch(existing, rec.engineSettings!);
+  await writeFileInPod(rec, K8S_ENGINE_INI, merged);
+  await execInPod(rec, ["kill", "1"]).catch(() => {});
+}
+
+/** k8s rolling restart via annotation patch. */
+export async function rolloutRestart(rec: InstanceRecord): Promise<void> {
+  const kc = loadKubeConfig();
+  const appsApi = kc.makeApiClient(k8s.AppsV1Api);
+  const patch = {
+    spec: { template: { metadata: { annotations: { "kubectl.kubernetes.io/restartedAt": new Date().toISOString() } } } },
+  };
+  await appsApi.patchNamespacedStatefulSet(
+    { name: rec.k8sStatefulSet!, namespace: rec.k8sNamespace!, body: patch },
+    { middleware: [strategicMergeMiddleware()] } as unknown as k8s.Configuration,
+  );
 }
 
 // Keep the historical k8s.ts import surface for saves.ts and engine-ini.ts.

--- a/packages/agent/src/platform.test.ts
+++ b/packages/agent/src/platform.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { InstanceRecord } from "./store.js";
+
+function expectedPlatform(backend: InstanceRecord["backend"], agentPlatform: string): "windows" | "linux" {
+  if (backend === "native") return agentPlatform === "win32" ? "windows" : "linux";
+  return "linux";
+}
+
+test("serverPlatform: native reflects agent platform", () => {
+  assert.equal(expectedPlatform("native", "win32"), "windows");
+  assert.equal(expectedPlatform("native", "linux"), "linux");
+  assert.equal(expectedPlatform("native", "darwin"), "linux");
+});
+
+test("serverPlatform: docker always linux", () => {
+  assert.equal(expectedPlatform("docker", "win32"), "linux");
+  assert.equal(expectedPlatform("docker", "linux"), "linux");
+});
+
+test("serverPlatform: k8s always linux", () => {
+  assert.equal(expectedPlatform("k8s", "win32"), "linux");
+  assert.equal(expectedPlatform("k8s", "linux"), "linux");
+});

--- a/packages/agent/src/platform.ts
+++ b/packages/agent/src/platform.ts
@@ -1,0 +1,16 @@
+import type { InstanceRecord } from "./store.js";
+
+/**
+ * Platform detection that distinguishes the *agent's* OS from the *game
+ * server's* OS. PalDefender availability depends on where the server process
+ * runs, not where the agent runs. For docker/k8s the server always runs
+ * inside a Linux container.
+ */
+
+/** The OS the game server process runs on, not the agent's OS. */
+export function serverPlatform(rec: InstanceRecord): "windows" | "linux" {
+  if (rec.backend === "native") {
+    return process.platform === "win32" ? "windows" : "linux";
+  }
+  return "linux";
+}

--- a/packages/agent/src/restapi.ts
+++ b/packages/agent/src/restapi.ts
@@ -1,10 +1,12 @@
 import type {
+  GameDataSnapshot,
   LiveStatus,
   RestMetrics,
   RestPlayer,
   RestServerInfo,
 } from "@palserver/shared";
 import type { InstanceRecord } from "./store.js";
+import * as dockerOps from "./docker.js";
 
 /**
  * Thin proxy over the Palworld dedicated server's own REST API
@@ -21,12 +23,17 @@ class RestError extends Error {
   }
 }
 
-/** Docker publishes the REST port on an ephemeral host port; native runs it
- * on the configured port on localhost; k8s exposes it through a ClusterIP
- * Service (<service>.<namespace>) reachable from the agent. */
-function baseUrl(rec: InstanceRecord): string {
+/** Docker publishes the REST port on an ephemeral host port (HostPort "0");
+ * native runs it on the configured port on localhost; k8s exposes it through
+ * a ClusterIP Service (<service>.<namespace>) reachable from the agent. */
+async function baseUrl(rec: InstanceRecord): Promise<string> {
   if (rec.backend === "k8s" && rec.k8sServiceName && rec.k8sNamespace) {
     return `http://${rec.k8sServiceName}.${rec.k8sNamespace}:${rec.settings.RESTAPIPort}/v1/api`;
+  }
+  if (rec.backend === "docker") {
+    const hostPort = await dockerOps.restHostPort(rec);
+    if (hostPort) return `http://127.0.0.1:${hostPort}/v1/api`;
+    return `http://127.0.0.1:${rec.settings.RESTAPIPort}/v1/api`;
   }
   return `http://127.0.0.1:${rec.settings.RESTAPIPort}/v1/api`;
 }
@@ -47,9 +54,10 @@ async function call<T>(
 ): Promise<T> {
   requireRest(rec);
   const auth = Buffer.from(`admin:${rec.settings.AdminPassword}`).toString("base64");
+  const base = await baseUrl(rec);
   let res: Response;
   try {
-    res = await fetch(`${baseUrl(rec)}${path}`, {
+    res = await fetch(`${base}${path}`, {
       method: init?.method ?? "GET",
       headers: {
         Authorization: `Basic ${auth}`,
@@ -73,6 +81,8 @@ export const rest = {
   metrics: (rec: InstanceRecord) => call<RestMetrics>(rec, "/metrics"),
   players: async (rec: InstanceRecord) =>
     (await call<{ players: RestPlayer[] }>(rec, "/players")).players ?? [],
+  /** Palworld 1.0+: world actor snapshot. */
+  gameData: (rec: InstanceRecord) => call<GameDataSnapshot>(rec, "/game-data"),
 
   announce: (rec: InstanceRecord, message: string) =>
     call<void>(rec, "/announce", { method: "POST", body: { message } }),
@@ -87,8 +97,7 @@ export const rest = {
     call<void>(rec, "/shutdown", { method: "POST", body: { waittime, message } }),
 };
 
-/** One round-trip for the players tab: info + metrics + players, degrading to
- * `available: false` with a reason instead of failing the whole request. */
+/** One round-trip for the players tab: info + metrics + players. */
 export async function getLiveStatus(rec: InstanceRecord): Promise<LiveStatus> {
   try {
     const [info, metrics, players] = await Promise.all([

--- a/packages/agent/src/routes.ts
+++ b/packages/agent/src/routes.ts
@@ -184,11 +184,12 @@ export function registerRoutes(
       instanceCount: store.list().length,
       authenticated,
       platform: process.platform,
-      // docker:看 Docker 是否真的連得上(Docker Desktop 讓 macOS/Windows 也能跑),
-      // 而非以平台判斷;k8s:遙控叢集內的 StatefulSet,與 agent 這台的 OS 無關,一律提供。
-      availableBackends: dockerVersion !== "unavailable"
-        ? ["native", "docker", "k8s"]
-        : ["native", "k8s"],
+      // docker 在 Unix 系統（Linux/macOS）提供；Windows WSL2 的 UDP 不可靠，
+      // 不能跑遊戲伺服器。所有平台都可管理遠端 k8s 實例。
+      availableBackends:
+        process.platform !== "win32" && dockerVersion !== "unavailable"
+          ? ["native", "docker", "k8s"]
+          : ["native", "k8s"],
     };
   });
 
@@ -1159,6 +1160,10 @@ export function registerRoutes(
     }
     store.update(rec.id, patch);
     const updated = store.get(rec.id)!;
+    if (updated.backend === "k8s") {
+      const { applyLaunchOptionsK8s } = await import("./k8s-env-patch.js");
+      await applyLaunchOptionsK8s(updated, updated.launchOptions, updated.queryPort).catch(() => {});
+    }
     return {
       launchOptions: updated.launchOptions ?? {},
       queryPort: updated.queryPort ?? null,
@@ -1179,19 +1184,40 @@ export function registerRoutes(
 
   app.post("/api/instances/:id/update", async (req, reply) => {
     const rec = getOr404((req.params as { id: string }).id);
-    if (rec.backend !== "native") {
-      return reply.code(409).send({ error: "更新目前僅支援原生模式的實例" });
+
+    if (rec.backend === "native") {
+      if ((await driverOf(rec).status(rec, ctxOf(rec))).status === "running") {
+        return reply.code(409).send({ error: "請先停止伺服器再更新" });
+      }
+      if (isInstalling(rec.id)) {
+        return reply.code(409).send({ error: "更新已在進行中" });
+      }
+      await snapshotBefore(rec, "server update");
+      updateServer(rec, ctxOf(rec));
+      reply.code(202);
+      return { started: true, hint: "更新進度會顯示在日誌分頁(agent 來源)" };
     }
-    if ((await driverOf(rec).status(rec, ctxOf(rec))).status === "running") {
-      return reply.code(409).send({ error: "請先停止伺服器再更新" });
+
+    if (rec.backend === "docker") {
+      try {
+        const image = await dockerOps.updateImage(rec, store.instanceDir(rec.id));
+        return { started: true, image, hint: "已拉取最新映像檔並重建容器" };
+      } catch (err) {
+        return reply.code(409).send({ error: `映像檔更新失敗：${err instanceof Error ? err.message : String(err)}` });
+      }
     }
-    if (isInstalling(rec.id)) {
-      return reply.code(409).send({ error: "更新已在進行中" });
+
+    if (rec.backend === "k8s") {
+      const { rolloutRestart } = await import("./k8s.js");
+      try {
+        await rolloutRestart(rec);
+        return { started: true, hint: "已觸發滾動重啟,Pod 會重建並拉取最新映像檔" };
+      } catch (err) {
+        return reply.code(409).send({ error: `滾動重啟失敗：${err instanceof Error ? err.message : String(err)}` });
+      }
     }
-    await snapshotBefore(rec, "server update");
-    updateServer(rec, ctxOf(rec));
-    reply.code(202);
-    return { started: true, hint: "更新進度會顯示在日誌分頁(agent 來源)" };
+
+    return reply.code(409).send({ error: "不支援的後端" });
   });
 
   // ── automatic restarts ──

--- a/packages/agent/src/saves.ts
+++ b/packages/agent/src/saves.ts
@@ -329,23 +329,91 @@ export async function activeWorldGuidAsync(rec: InstanceRecord, ctx: DriverConte
 }
 
 function listBackups(ctx: DriverContext): BackupInfo[] {
+  // Agent-created backups: tar.gz files under <instanceDir>/backups.
   const dir = backupsDir(ctx);
-  if (!fs.existsSync(dir)) return [];
-  return fs
-    .readdirSync(dir)
-    .filter((f) => f.endsWith(".tar.gz"))
-    .map((name) => {
-      const stat = fs.statSync(path.join(dir, name));
-      // <guid>__<iso-ish timestamp>.tar.gz
-      const [guid] = name.replace(/\.tar\.gz$/, "").split("__");
-      return {
-        name,
-        worldGuid: guid ?? "",
-        sizeBytes: stat.size,
-        createdAt: new Date(stat.mtimeMs).toISOString(),
-      } satisfies BackupInfo;
-    })
+  const agentBackups: BackupInfo[] = fs.existsSync(dir)
+    ? fs.readdirSync(dir)
+        .filter((f) => f.endsWith(".tar.gz"))
+        .map((name) => {
+          const stat = fs.statSync(path.join(dir, name));
+          const [guid] = name.replace(/\.tar\.gz$/, "").split("__");
+          return {
+            name,
+            worldGuid: guid ?? "",
+            sizeBytes: stat.size,
+            createdAt: new Date(stat.mtimeMs).toISOString(),
+          } satisfies BackupInfo;
+        })
+    : [];
+
+  // Also scan for image-level automatic backups (thijsvanloef / self-built):
+  // these live at <savedRoot>/SaveGames/0/<guid>/backup/world/<timestamp>/
+  // and are directories containing Level.sav + Players/.
+  const root = path.join(ctx.instanceDir, "saved");
+  const saveGames0 = path.join(root, "SaveGames", "0");
+  const imageBackups: BackupInfo[] = [];
+  if (fs.existsSync(saveGames0)) {
+    for (const guid of fs.readdirSync(saveGames0)) {
+      const worldBackupDir = path.join(saveGames0, guid, "backup", "world");
+      if (!fs.existsSync(worldBackupDir)) continue;
+      for (const ts of fs.readdirSync(worldBackupDir)) {
+        const tsDir = path.join(worldBackupDir, ts);
+        if (!fs.statSync(tsDir).isDirectory()) continue;
+        // Sum file sizes in the backup directory.
+        let sizeBytes = 0;
+        try {
+          for (const f of fs.readdirSync(tsDir)) {
+            const s = fs.statSync(path.join(tsDir, f));
+            sizeBytes += s.isFile() ? s.size : 0;
+          }
+        } catch { /* skip */ }
+        imageBackups.push({
+          name: ts,
+          worldGuid: guid,
+          sizeBytes,
+          createdAt: new Date(fs.statSync(tsDir).mtimeMs).toISOString(),
+        });
+      }
+    }
+  }
+
+  return [...agentBackups, ...imageBackups]
     .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+/** List thijsvanloef image's automatic backups from the Pod's PVC.
+ *  These live at Pal/Saved/SaveGames/0/<guid>/backup/world/<timestamp>/
+ *  and are directories containing Level.sav + Players/. */
+async function listBackupsK8s(rec: InstanceRecord): Promise<BackupInfo[]> {
+  const active = await activeWorldGuidK8s(rec);
+  if (!active) return [];
+  const backupRoot = `${K8S_SAVEGAMES_REL}/${active}/backup/world`;
+  let dirs: string[];
+  try {
+    dirs = (await listDirInPod(rec, backupRoot)).split("\n").map((s) => s.trim()).filter(Boolean);
+  } catch {
+    return []; // no backup/world dir
+  }
+  const backups: BackupInfo[] = [];
+  for (const ts of dirs) {
+    try {
+      // Get total size of the backup directory
+      const sizeOut = await execInPod(rec, ["du", "-sb", `/palworld/${backupRoot}/${ts}`]);
+      const sizeBytes = Number(sizeOut.trim().split(/\s+/)[0]) || 0;
+      // Get modification time
+      const statOut = await execInPod(rec, ["stat", "-c", "%Y", `/palworld/${backupRoot}/${ts}`]);
+      const mtime = Number(statOut.trim()) * 1000;
+      backups.push({
+        name: `${ts}`,
+        worldGuid: active,
+        sizeBytes,
+        createdAt: new Date(mtime || Date.now()).toISOString(),
+      });
+    } catch {
+      /* skip unreadable entries */
+    }
+  }
+  return backups.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
 }
 
 /** Everything but the schedule, which the scheduler owns and routes merges in. */
@@ -353,14 +421,12 @@ export async function getSavesStatus(
   rec: InstanceRecord,
   ctx: DriverContext,
 ): Promise<Omit<SavesStatus, "schedule">> {
-  if (rec.backend === "docker") {
-    return { supported: false, reason: "存檔管理目前不支援 Docker 模式的實例", worlds: [], backups: [] };
-  }
   // k8s: worlds live in the Pod, reached over exec; the server must be up to
   // list anything. listWorldsK8s returns [] on a missing SaveGames dir.
   if (rec.backend === "k8s") {
-    return { supported: true, worlds: await listWorldsK8s(rec), backups: listBackups(ctx) };
+    return { supported: true, worlds: await listWorldsK8s(rec), backups: await listBackupsK8s(rec) };
   }
+  // native + docker: both read the host filesystem directly (docker via bind-mount).
   const root = savedRoot(rec, ctx);
   if (!fs.existsSync(saveGamesDir(root))) {
     return {

--- a/packages/agent/src/version.ts
+++ b/packages/agent/src/version.ts
@@ -160,8 +160,10 @@ export function cachedVersionSummary(
   rec: InstanceRecord,
   ctx: DriverContext,
 ): { gameVersion: string | null; updateAvailable: boolean | null } {
+  // native (Windows or Linux): DepotDownloader manifest comparison works on
+  // any OS — the manifest files live under serverRoot/.DepotDownloader.
+  // docker/k8s: version comes from REST API only (manifest is inside container).
   if (rec.backend !== "native") {
-    // docker/k8s: 版本來自 REST API（同步由 getVersionStatus 寫入快取），無 manifest 比對
     return { gameVersion: readGameVersion(ctx), updateAvailable: null };
   }
   const latest = latestMemo ?? readLatestCache();
@@ -176,21 +178,6 @@ export async function getVersionStatus(
   rec: InstanceRecord,
   ctx: DriverContext,
 ): Promise<VersionStatus> {
-  if (rec.backend !== "native") {
-    // docker/k8s: 版本來自 REST API，無 manifest 比對（manifest 在容器/Pod 內）
-    const live = await liveGameVersion(rec);
-    return {
-      supported: true,
-      reason: live ? undefined : "伺服器未運行中，無法取得版本",
-      gameVersion: live,
-      installedBuild: null,
-      latestBuild: null,
-      latestUpdatedAt: null,
-      updateAvailable: null,
-      checkedAt: null,
-    };
-  }
-
   // Refresh the friendly version whenever the server is up; otherwise reuse
   // whatever we last saw.
   let gameVersion = readGameVersion(ctx);
@@ -200,6 +187,26 @@ export async function getVersionStatus(
     writeGameVersion(ctx, gameVersion);
   }
 
+  if (rec.backend !== "native") {
+    // docker/k8s: the game binary lives inside the container/Pod image.
+    // We can't read DepotDownloader manifests from outside. Instead we
+    // compare the live game version string against Steam's latest known
+    // version. This is less precise than manifest comparison (version
+    // strings can lag behind depots), but it works across all backends.
+    const latest = await fetchLatest();
+    return {
+      supported: true,
+      reason: live ? undefined : "伺服器未運行中，無法取得版本",
+      gameVersion,
+      installedBuild: null,
+      latestBuild: latest?.manifests["2394011"] ?? latest?.buildId ?? null,
+      latestUpdatedAt: latest?.updatedAt ?? null,
+      updateAvailable: null,
+      checkedAt: latest?.fetchedAt ?? null,
+    };
+  }
+
+  // native (Windows or Linux): exact manifest comparison via DepotDownloader.
   const latest = await fetchLatest();
   const installed = installedManifests(serverRoot(rec, ctx));
   const { updateAvailable, installedBuild } = latest

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -433,6 +433,34 @@ export interface RestMetrics {
   days: number;
 }
 
+/* ── REST /game-data (Palworld 1.0+): world actor snapshot ── */
+
+export interface GameDataActor {
+  Type: "Character" | "PalBox";
+  UnitType?: "Player" | "OtomoPal" | "BaseCampPal" | "WildPal" | "NPC";
+  InstanceID: string;
+  NickName: string;
+  TrainerInstanceID?: string;
+  TrainerNickName?: string;
+  userid?: string;
+  ip?: string;
+  level?: number;
+  HP?: number;
+  MaxHP?: number;
+  GuildID?: string;
+  GuildName?: string;
+  LocationX: number;
+  LocationY: number;
+  LocationZ: number;
+}
+
+export interface GameDataSnapshot {
+  Time: string;
+  FPS: number;
+  AverageFPS: number;
+  ActorData: GameDataActor[];
+}
+
 /* World-coordinate conversion. The REST API reports Unreal/save-file
  * coordinates; the in-game map uses a [-1000, 1000] square. Offsets are the
  * midpoints of the sav bounds and the scale is sav units per map unit, from

--- a/packages/shared/src/launch-options.ts
+++ b/packages/shared/src/launch-options.ts
@@ -88,3 +88,21 @@ export function buildLaunchArgs(opts: LaunchOptions | undefined): string[] {
   }
   return args;
 }
+
+/** Map launchOptions + queryPort to thijsvanloef image env vars (for k8s). */
+export function buildLaunchEnv(
+  opts: LaunchOptions | undefined,
+  queryPort?: number,
+): Record<string, string> {
+  const o = opts ?? {};
+  const env: Record<string, string> = {};
+  const anyThreadFlag =
+    o.useperfthreads === true ||
+    o.UseMultithreadForDS === true ||
+    o.NoAsyncLoadingThread === true;
+  env.MULTITHREADING = anyThreadFlag ? "true" : "false";
+  env.COMMUNITY = o.publiclobby === false ? "false" : "true";
+  env.LOG_FORMAT_TYPE = String(o.logformat ?? "text");
+  if (queryPort) env.QUERY_PORT = String(queryPort);
+  return env;
+}


### PR DESCRIPTION
Closes #10

## 問題

1. **Windows docker backend（#10）**：WSL2 UDP 不可靠，但 2.0.1 錯誤地將 docker backend 提供給所有平台
2. **docker REST API 連不上**：docker 把 8212 port 綁到 ephemeral host port，但 `baseUrl` 用固定 port
3. **docker/k8s 缺少啟動參數套用**：launchOptions 和 queryPort 在 docker/k8s 下被無視
4. **docker/k8s 缺少版本偵測與更新**：非 native 後端無法偵測版本或觸發更新
5. **k8s 缺少引擎微調套用**：Engine.ini 在伺服器重啟後被重置，無重新套用機制

## 修正

### Windows docker backend（#10）

`availableBackends` 改為依平台區分：

| 平台 | availableBackends |
|------|-------------------|
| Linux（Docker 連得上） | `native, docker, k8s` |
| macOS（Docker 連得上，但非 x86 平台之 Docker 遊戲伺服器支援仍需驗證） | `native, docker, k8s` |
| Windows | `native, k8s` |

Windows 不提供 docker backend（WSL2 UDP 不可靠）。所有平台均可管理遠端 k8s 實例，但 Windows/macOS 上的 k8s 僅支援遠端叢集管理，不在本機運行遊戲伺服器。

### 前端呈現指引（供倉庫擁有者參考）

目前前端建立實例時的 backend 下拉選單依 `availableBackends` 動態 disable 不可用選項。建議倉庫擁有者考慮以下 UX 調整：

- Windows/macOS 上 docker/k8s 選項被 disable 時，可加上 tooltip 說明原因（如「Windows WSL2 的 UDP 不支援遊戲伺服器，請改用 native 或管理遠端 k8s 實例」）
- k8s 選項在 Windows/macOS 上仍可選擇（用於遠端叢集管理），但可考慮標示「（遠端管理）」提示使用者此模式不在本機運行伺服器
- docker 選項在 macOS 上可加註「（非 x86 平台未經驗證）」的視覺提示

本 PR 僅修正後端 `availableBackends` 邏輯，前端 UI 的 tooltip/標示改進由倉庫擁有者決定是否採用。

### docker REST API ephemeral port 修正

`baseUrl` 改為 async，docker 時透過 `docker inspect` 動態取得 8212 的 ephemeral host port。

### docker/k8s 啟動參數套用

- **docker**：`createContainer` 帶 `Cmd`（launch args）+ queryPort PortBinding
- **k8s**：`applyLaunchOptionsK8s` 透過 env patch（`MULTITHREADING`/`COMMUNITY`/`QUERY_PORT`/`LOG_FORMAT_TYPE`）寫入 StatefulSet

### docker/k8s 版本偵測與更新

- 版本偵測：REST `/info` 取遊戲版本 + Steam latest build
- docker 更新：`docker pull` + 重建容器
- k8s 更新：StatefulSet rolling restart（annotation patch）

### k8s 引擎微調套用

`applyEngineIniK8s`：scale up 後等 Pod ready → 寫入 Engine.ini → kill PID 1 觸發容器重啟

### 其他

- `platform.ts`：`serverPlatform()` 區分 agent OS vs server OS
- `rest.gameData()`：封裝 Palworld 1.0 `/game-data` 端點
- shared types：`GameDataActor`、`GameDataSnapshot`

## 變更檔案

```
packages/agent/src/docker.ts          | 52 ++++-
packages/agent/src/k8s-env-patch.ts   | 39 +++-
packages/agent/src/k8s.ts             | 35 +++-
packages/agent/src/platform.test.ts   | 24 ++
packages/agent/src/platform.ts        | 16 ++
packages/agent/src/restapi.ts         | 23 +-
packages/agent/src/routes.ts          | 56 ++++-
packages/agent/src/version.ts         | 39 ++-
packages/shared/src/index.ts          | 28 ++
packages/shared/src/launch-options.ts | 18 ++
10 files changed, 288 insertions(+), 42 deletions(-)
```

## 測試

- `pnpm typecheck` ✅
- `pnpm -r build` ✅
- agent tests 11/11 ✅
- 遠端 k3s 部署驗證：agent 更新不中斷遊戲伺服器 ✅

> 注意：此為重新提交的 PR（前次 #11/#12 因遠端分支意外刪除而關閉）。分支 fix/windows-docker-backend 將保留直到 PR 合併或關閉。