### PR TITLE
fix: 重啟前確保存檔安全

### DIFF
--- a/packages/agent/src/supervisor.ts
+++ b/packages/agent/src/supervisor.ts
@@ -328,9 +328,28 @@ export class RestartSupervisor {
           .catch(() => {}); // REST off — restart anyway, just without warning
         await new Promise((r) => setTimeout(r, wait * 1000));
       }
+      // Save and wait for the world to flush to disk. The REST /save
+      // endpoint returns 200 immediately but the actual write is async —
+      // stopping too soon can corrupt save files. We save, then wait a
+      // few seconds before stopping to let the server finish writing.
       await rest.save(rec).catch(() => {});
+      await new Promise((r) => setTimeout(r, 5000));
 
-      await driver.stop(rec, ctx);
+      // Try graceful shutdown first (server saves then exits cleanly).
+      // Fall back to hard stop if REST is unavailable or shutdown fails.
+      const shutdownOk = await rest
+        .shutdown(rec, 10, `自動重啟: ${detail}`)
+        .then(() => true)
+        .catch(() => false);
+
+      if (!shutdownOk) {
+        await driver.stop(rec, ctx);
+      } else {
+        // Graceful shutdown succeeded — the server is (or soon will be) stopped.
+        // Wait a moment for the process to fully exit, then sync driver state.
+        await new Promise((r) => setTimeout(r, 5000));
+      }
+
       await driver.start(rec, ctx);
 
       const now = new Date().toISOString();


### PR DESCRIPTION
Closes #16

## 問題

排程重啟時 `rest.save()` 後立即 `driver.stop()`，但 REST `/save` 是非同步的——存檔可能正在寫入時被 stop 中斷，導致存檔毀損。

## 修正

重啟流程改為：

1. `rest.save()` — 送出存檔請求
2. **等待 5 秒** — 讓伺服器完成寫盤
3. **`rest.shutdown(rec, 10, ...)` — graceful shutdown**（伺服器自己存檔後乾淨退出，倒數 10 秒）
4. graceful shutdown 失敗時才 fallback 到 `driver.stop()`
5. `driver.start()` — 重啟

## 變更

`packages/agent/src/supervisor.ts`：restart 方法加入存檔等待 + graceful shutdown