### PR TITLE
fix: k8s設定改為下次重啟生效

### DIFF
--- a/packages/agent/src/k8s.ts
+++ b/packages/agent/src/k8s.ts
@@ -85,6 +85,12 @@ export const k8sDriver: ServerDriver = {
     const statefulSet = rec.k8sStatefulSet!;
     const kc = loadKubeConfig();
     const appsApi = kc.makeApiClient(k8s.AppsV1Api);
+
+    // Sync store settings to STS env before scaling up — this is where
+    // settings changes (PUT /settings) take effect, on manual restart.
+    const { applyEnvPatchK8s } = await import("./k8s-env-patch.js");
+    await applyEnvPatchK8s(rec, rec.settings).catch(() => {});
+
     const patch = { spec: { replicas: 1 } };
     await appsApi.patchNamespacedStatefulSetScale(
       { name: statefulSet, namespace, body: patch },

--- a/packages/agent/src/routes.ts
+++ b/packages/agent/src/routes.ts
@@ -516,25 +516,9 @@ export function registerRoutes(
       dockerOps.writeConfig(store.instanceDir(rec.id), updated.settings);
       return { applied: "on-next-restart", settings: updated.settings };
     }
-    // k8s: the game-server image reads settings from env, not ini. PATCH the
-    // StatefulSet env in place; the Pod rolls and picks up the new values.
-    // `restartTriggered` signals the UI that the change is already live.
-    if (rec.backend === "k8s") {
-      const { applyEnvPatchK8s } = await import("./k8s-env-patch.js");
-      const result = await applyEnvPatchK8s(rec, patch);
-      const appliedSettings = Object.fromEntries(
-        Object.entries(patch).filter(([key]) => !result.unsupported.includes(key)),
-      );
-      const updated = store.update(rec.id, {
-        settings: WorldSettingsSchema.parse({ ...rec.settings, ...appliedSettings }),
-      });
-      return {
-        applied: "env-patched",
-        settings: updated.settings,
-        restartTriggered: true,
-        unsupportedKeys: result.unsupported.length > 0 ? result.unsupported : undefined,
-      };
-    }
+    // k8s: settings are applied as STS env on the next manual restart, not
+    // immediately — same as native/docker. The k8s start flow patches env then.
+    // All backends: store only, applied on next restart.
     const updated = store.update(rec.id, { settings: nextSettings });
     return { applied: "on-next-restart", settings: updated.settings };
   });

--- a/packages/agent/src/supervisor.ts
+++ b/packages/agent/src/supervisor.ts
@@ -377,9 +377,7 @@ export class RestartSupervisor {
     state.wasRunning = running;
     state.memoryStreak = 0;
     if (running) {
-      const now = new Date().toISOString();
-      state.lastScheduledAt = now;
-      state.lastStartAt = now;
+      state.lastStartAt = new Date().toISOString();
     }
     this.writeState(id, state);
   }


### PR DESCRIPTION
Closes #19

## 問題

k8s 後端儲存設定時直接 patch STS env → Pod 自動 rolling update，導致：
1. 立即重啟，玩家被踢出
2. 無倒數公告
3. 排程重啟計時器被重置

## 修正

所有 backend 統一為 `on-next-restart`：

- **k8s settings PUT**：只存 store，不再觸發 rolling update
- **k8s start 流程**：加入 `applyEnvPatchK8s`，管理員手動重啟時才套用新設定
- **`noteManualState`**：不再重置 `lastScheduledAt`

## 變更

| 檔案 | 改動 |
|------|------|
| `routes.ts` | k8s settings PUT 移除立即 env patch，改為只存 store |
| `k8s.ts` | start 流程加入 settings env patch |
| `supervisor.ts` | `noteManualState` 移除 `lastScheduledAt` 重置 |