### PR TITLE
fix: REST port與設定寫入ini

### DIFF
--- a/packages/agent/src/docker.ts
+++ b/packages/agent/src/docker.ts
@@ -84,8 +84,9 @@ export async function createContainer(
     bindings[`${rec.queryPort}/udp`] = [{ HostPort: String(rec.queryPort) }];
   }
   if (rec.settings.RESTAPIEnabled) {
-    ports["8212/tcp"] = {};
-    bindings["8212/tcp"] = [{ HostPort: "0" }];
+    const restPort = String(rec.settings.RESTAPIPort);
+    ports[`${restPort}/tcp`] = {};
+    bindings[`${restPort}/tcp`] = [{ HostPort: "0" }];
   }
 
   const launchArgs = [
@@ -257,7 +258,7 @@ export async function restHostPort(rec: InstanceRecord): Promise<number | null> 
   const container = await findContainer(rec);
   if (!container) return null;
   const info = await container.inspect();
-  const binding = info.NetworkSettings.Ports["8212/tcp"];
+  const binding = info.NetworkSettings.Ports[`${rec.settings.RESTAPIPort}/tcp`];
   return binding?.[0]?.HostPort ? Number(binding[0].HostPort) : null;
 }
 

--- a/packages/agent/src/routes.ts
+++ b/packages/agent/src/routes.ts
@@ -518,8 +518,20 @@ export function registerRoutes(
     }
     // k8s: settings are applied as STS env on the next manual restart, not
     // immediately — same as native/docker. The k8s start flow patches env then.
-    // All backends: store only, applied on next restart.
+    // native: write ini immediately (same as docker) so the file is up-to-date
+    // even while the server is running — Palworld overwrites ini on shutdown,
+    // but the next start picks up the agent-rendered file first.
+    // All backends: store + persist to ini/env, applied on next restart.
     const updated = store.update(rec.id, { settings: nextSettings });
+    if (updated.backend === "native") {
+      const { renderPalWorldSettingsIni } = await import("./settings-ini.js");
+      const fs = await import("node:fs");
+      const path = await import("node:path");
+      const { serverRoot } = await import("./native.js");
+      const configDir = path.join(serverRoot(updated, ctxOf(updated)), "Pal", "Saved", "Config", process.platform === "win32" ? "WindowsServer" : "LinuxServer");
+      fs.mkdirSync(configDir, { recursive: true });
+      fs.writeFileSync(path.join(configDir, "PalWorldSettings.ini"), renderPalWorldSettingsIni(updated.settings));
+    }
     return { applied: "on-next-restart", settings: updated.settings };
   });
 


### PR DESCRIPTION
Closes #24

## 問題

1. **docker.ts 寫死 8212**：`createContainer` expose port 和 `restHostPort` 硬編碼 8212，不讀 `rec.settings.RESTAPIPort`
2. **native 改設定不寫 ini**：docker settings PUT 立即寫 ini，但 native 只存 store。使用者改 AdminPassword 後伺服器還在跑，Palworld 關機覆蓋 ini，下次啟動讀到舊值（#23 根因之一）

## 修正

- docker.ts expose port + restHostPort 改讀 `rec.settings.RESTAPIPort`
- native settings PUT 立即寫 ini（跟 docker 行為一致）
- k8s 不需改（設定載體是 STS env，在 start 流程的 `applyEnvPatchK8s` 套用）

## 變更

| 檔案 | 改動 |
|------|------|
| `docker.ts` | expose port + restHostPort 讀 settings |
| `routes.ts` | native settings PUT 立即寫 ini |