### PR TITLE
fix: native設定即時寫ini

### DIFF
--- a/packages/agent/src/routes.ts
+++ b/packages/agent/src/routes.ts
@@ -516,10 +516,19 @@ export function registerRoutes(
       dockerOps.writeConfig(store.instanceDir(rec.id), updated.settings);
       return { applied: "on-next-restart", settings: updated.settings };
     }
-    // k8s: settings are applied as STS env on the next manual restart, not
-    // immediately — same as native/docker. The k8s start flow patches env then.
-    // All backends: store only, applied on next restart.
+    // k8s: settings are applied as STS env on the next manual restart.
+    // native: write ini immediately (same as docker) so the file is up-to-date
+    // even while the server is running.
     const updated = store.update(rec.id, { settings: nextSettings });
+    if (updated.backend === "native") {
+      const { renderPalWorldSettingsIni } = await import("./settings-ini.js");
+      const fs = await import("node:fs");
+      const path = await import("node:path");
+      const { serverRoot } = await import("./native.js");
+      const configDir = path.join(serverRoot(updated, ctxOf(updated)), "Pal", "Saved", "Config", process.platform === "win32" ? "WindowsServer" : "LinuxServer");
+      fs.mkdirSync(configDir, { recursive: true });
+      fs.writeFileSync(path.join(configDir, "PalWorldSettings.ini"), renderPalWorldSettingsIni(updated.settings));
+    }
     return { applied: "on-next-restart", settings: updated.settings };
   });
 


### PR DESCRIPTION
Closes #26

## 問題

docker settings PUT 立即寫 ini，但 native 只存 store。使用者改 AdminPassword 後伺服器在跑時，Palworld 關機覆蓋 ini，下次啟動可能讀到舊值。

## 修正

native settings PUT 立即寫 PalWorldSettings.ini（跟 docker 行為一致）。

## 變更

`packages/agent/src/routes.ts`：native settings PUT 加入 `renderPalWorldSettingsIni` + `fs.writeFileSync`