### PR TITLE
fix: REST埠1:1及鏡像port衝突檢測

### DIFF
--- a/packages/agent/src/docker.ts
+++ b/packages/agent/src/docker.ts
@@ -84,8 +84,9 @@ export async function createContainer(
     bindings[`${rec.queryPort}/udp`] = [{ HostPort: String(rec.queryPort) }];
   }
   if (rec.settings.RESTAPIEnabled) {
-    ports["8212/tcp"] = {};
-    bindings["8212/tcp"] = [{ HostPort: "0" }];
+    const restPort = rec.settings.RESTAPIPort;
+    ports[`${restPort}/tcp`] = {};
+    bindings[`${restPort}/tcp`] = [{ HostPort: String(restPort) }];
   }
 
   const launchArgs = [
@@ -250,15 +251,6 @@ export async function listInContainer(
   dirPath: string,
 ): Promise<string> {
   return execInContainer(rec, ["ls", "-1", dirPath]).then((s) => s.trim());
-}
-
-/** Resolve the ephemeral host port Docker assigned for the REST API (8212/tcp). */
-export async function restHostPort(rec: InstanceRecord): Promise<number | null> {
-  const container = await findContainer(rec);
-  if (!container) return null;
-  const info = await container.inspect();
-  const binding = info.NetworkSettings.Ports["8212/tcp"];
-  return binding?.[0]?.HostPort ? Number(binding[0].HostPort) : null;
 }
 
 /** Pull latest image and recreate container. */

--- a/packages/agent/src/restapi.ts
+++ b/packages/agent/src/restapi.ts
@@ -6,7 +6,6 @@ import type {
   RestServerInfo,
 } from "@palserver/shared";
 import type { InstanceRecord } from "./store.js";
-import * as dockerOps from "./docker.js";
 
 /**
  * Thin proxy over the Palworld dedicated server's own REST API
@@ -23,17 +22,12 @@ class RestError extends Error {
   }
 }
 
-/** Docker publishes the REST port on an ephemeral host port (HostPort "0");
- * native runs it on the configured port on localhost; k8s exposes it through
- * a ClusterIP Service (<service>.<namespace>) reachable from the agent. */
+/** docker/native: REST API on 127.0.0.1:<RESTAPIPort>; k8s: ClusterIP Service
+ * (<service>.<namespace>) reachable from the agent. All backends use
+ * RESTAPIPort directly — docker binds container port = host port (1:1). */
 async function baseUrl(rec: InstanceRecord): Promise<string> {
   if (rec.backend === "k8s" && rec.k8sServiceName && rec.k8sNamespace) {
     return `http://${rec.k8sServiceName}.${rec.k8sNamespace}:${rec.settings.RESTAPIPort}/v1/api`;
-  }
-  if (rec.backend === "docker") {
-    const hostPort = await dockerOps.restHostPort(rec);
-    if (hostPort) return `http://127.0.0.1:${hostPort}/v1/api`;
-    return `http://127.0.0.1:${rec.settings.RESTAPIPort}/v1/api`;
   }
   return `http://127.0.0.1:${rec.settings.RESTAPIPort}/v1/api`;
 }

--- a/packages/agent/src/routes.ts
+++ b/packages/agent/src/routes.ts
@@ -395,18 +395,16 @@ export function registerRoutes(
     if (store.findByName(input.name)) {
       return reply.code(409).send({ error: `instance "${input.name}" already exists` });
     }
-    const portTaken = input.backend !== "k8s" && store.list().some((r) => r.gamePort === input.gamePort);
-    if (portTaken) {
+    // 所有 backend 統一 port 衝突檢測：外部連線需 1:1 映射正確，每實例 port 唯一。
+    const gameTaken = store.list().some((r) => r.gamePort === input.gamePort);
+    if (gameTaken) {
       return reply.code(409).send({ error: `game port ${input.gamePort} already in use` });
     }
-    // docker/native: REST API port 在 host 層暴露，需每實例唯一。k8s 由 namespace
-    // + ClusterIP 隔離，不需檢測。
-    if (input.backend !== "k8s" && input.settings?.RESTAPIEnabled !== false) {
+    if (input.settings?.RESTAPIEnabled !== false) {
       const restTaken = store
         .list()
         .some(
           (r) =>
-            r.backend !== "k8s" &&
             r.settings.RESTAPIEnabled &&
             r.settings.RESTAPIPort === (input.settings?.RESTAPIPort ?? 8212),
         );
@@ -486,9 +484,8 @@ export function registerRoutes(
         // game-server 未運行或 INI 不存在 — 用 caller 帶入的 settings
       }
     }
-    // docker/native: 自動分配唯一的 REST API port（仿 queryPort 自動分配）。
-    // k8s 由 namespace + ClusterIP 隔離，不需要。
-    if (input.backend !== "k8s" && settings.RESTAPIEnabled) {
+    // 自動分配唯一的 REST API port（仿 queryPort 自動分配）。
+    if (settings.RESTAPIEnabled) {
       settings.RESTAPIPort = store.nextRestApiPort();
     }
     const rec = store.create({
@@ -530,25 +527,42 @@ export function registerRoutes(
     const rec = getOr404((req.params as { id: string }).id);
     const patch = UpdateSettingsSchema.parse(req.body);
     const nextSettings = WorldSettingsSchema.parse({ ...rec.settings, ...patch });
-    // docker/native: REST API port 在 host 層暴露，變更時需檢測衝突。
-    if (
-      rec.backend !== "k8s" &&
-      nextSettings.RESTAPIEnabled &&
-      nextSettings.RESTAPIPort !== rec.settings.RESTAPIPort
-    ) {
-      const restTaken = store
-        .list()
-        .some(
-          (r) =>
-            r.id !== rec.id &&
-            r.backend !== "k8s" &&
-            r.settings.RESTAPIEnabled &&
-            r.settings.RESTAPIPort === nextSettings.RESTAPIPort,
-        );
+    // 所有 backend 統一 port 衝突檢測：外部連線需 1:1 映射正確。
+    if (nextSettings.RESTAPIEnabled && nextSettings.RESTAPIPort !== rec.settings.RESTAPIPort) {
+      const restTaken = store.list().some(
+        (r) =>
+          r.id !== rec.id &&
+          r.settings.RESTAPIEnabled &&
+          r.settings.RESTAPIPort === nextSettings.RESTAPIPort,
+      );
       if (restTaken) {
         return reply.code(409).send({
           error: `REST API port ${nextSettings.RESTAPIPort} already in use`,
         });
+      }
+    }
+    // game port (PublicPort) 衝突檢測。
+    if (nextSettings.PublicPort !== rec.settings.PublicPort) {
+      const portTaken = store.list().some(
+        (r) => r.id !== rec.id && r.gamePort === nextSettings.PublicPort,
+      );
+      if (portTaken) {
+        return reply.code(409).send({ error: `game port ${nextSettings.PublicPort} already in use` });
+      }
+    }
+    // RCON port 衝突檢測（僅 RCONEnabled 時）。
+    if (
+      nextSettings.RCONEnabled &&
+      nextSettings.RCONPort !== rec.settings.RCONPort
+    ) {
+      const rconTaken = store.list().some(
+        (r) =>
+          r.id !== rec.id &&
+          r.settings.RCONEnabled &&
+          r.settings.RCONPort === nextSettings.RCONPort,
+      );
+      if (rconTaken) {
+        return reply.code(409).send({ error: `RCON port ${nextSettings.RCONPort} already in use` });
       }
     }
     await snapshotBefore(rec, "world settings update");
@@ -746,7 +760,12 @@ export function registerRoutes(
     let gamePort = rec.gamePort + 1;
     while (usedPorts.has(gamePort)) gamePort++;
 
-    const settings = WorldSettingsSchema.parse({ ...rec.settings, ServerName: name, PublicPort: gamePort });
+    const settings = WorldSettingsSchema.parse({
+      ...rec.settings,
+      ServerName: name,
+      PublicPort: gamePort,
+      ...(rec.settings.RESTAPIEnabled ? { RESTAPIPort: store.nextRestApiPort() } : {}),
+    });
     // 新實例沿用來源的 backend（native 走 host FS，docker 走 bind-mount）。
     const created = store.create({
       name,

--- a/packages/agent/src/routes.ts
+++ b/packages/agent/src/routes.ts
@@ -399,6 +399,23 @@ export function registerRoutes(
     if (portTaken) {
       return reply.code(409).send({ error: `game port ${input.gamePort} already in use` });
     }
+    // docker/native: REST API port 在 host 層暴露，需每實例唯一。k8s 由 namespace
+    // + ClusterIP 隔離，不需檢測。
+    if (input.backend !== "k8s" && input.settings?.RESTAPIEnabled !== false) {
+      const restTaken = store
+        .list()
+        .some(
+          (r) =>
+            r.backend !== "k8s" &&
+            r.settings.RESTAPIEnabled &&
+            r.settings.RESTAPIPort === (input.settings?.RESTAPIPort ?? 8212),
+        );
+      if (restTaken) {
+        return reply.code(409).send({
+          error: `REST API port ${input.settings?.RESTAPIPort ?? 8212} already in use`,
+        });
+      }
+    }
     let serverDir: string | undefined;
     let serverDirManaged: boolean | undefined;
     if (input.serverDir?.trim()) {
@@ -469,6 +486,11 @@ export function registerRoutes(
         // game-server 未運行或 INI 不存在 — 用 caller 帶入的 settings
       }
     }
+    // docker/native: 自動分配唯一的 REST API port（仿 queryPort 自動分配）。
+    // k8s 由 namespace + ClusterIP 隔離，不需要。
+    if (input.backend !== "k8s" && settings.RESTAPIEnabled) {
+      settings.RESTAPIPort = store.nextRestApiPort();
+    }
     const rec = store.create({
       name: input.name,
       backend: input.backend,
@@ -504,10 +526,31 @@ export function registerRoutes(
     };
   });
 
-  app.put("/api/instances/:id/settings", async (req) => {
+  app.put("/api/instances/:id/settings", async (req, reply) => {
     const rec = getOr404((req.params as { id: string }).id);
     const patch = UpdateSettingsSchema.parse(req.body);
     const nextSettings = WorldSettingsSchema.parse({ ...rec.settings, ...patch });
+    // docker/native: REST API port 在 host 層暴露，變更時需檢測衝突。
+    if (
+      rec.backend !== "k8s" &&
+      nextSettings.RESTAPIEnabled &&
+      nextSettings.RESTAPIPort !== rec.settings.RESTAPIPort
+    ) {
+      const restTaken = store
+        .list()
+        .some(
+          (r) =>
+            r.id !== rec.id &&
+            r.backend !== "k8s" &&
+            r.settings.RESTAPIEnabled &&
+            r.settings.RESTAPIPort === nextSettings.RESTAPIPort,
+        );
+      if (restTaken) {
+        return reply.code(409).send({
+          error: `REST API port ${nextSettings.RESTAPIPort} already in use`,
+        });
+      }
+    }
     await snapshotBefore(rec, "world settings update");
     // The driver re-renders the ini on every start; pre-render for docker so
     // the bind-mounted config is already in place.
@@ -516,10 +559,19 @@ export function registerRoutes(
       dockerOps.writeConfig(store.instanceDir(rec.id), updated.settings);
       return { applied: "on-next-restart", settings: updated.settings };
     }
-    // k8s: settings are applied as STS env on the next manual restart, not
-    // immediately — same as native/docker. The k8s start flow patches env then.
-    // All backends: store only, applied on next restart.
+    // k8s: settings are applied as STS env on the next manual restart.
+    // native: write ini immediately (same as docker) so the file is up-to-date
+    // even while the server is running.
     const updated = store.update(rec.id, { settings: nextSettings });
+    if (updated.backend === "native") {
+      const { renderPalWorldSettingsIni } = await import("./settings-ini.js");
+      const fs = await import("node:fs");
+      const path = await import("node:path");
+      const { serverRoot } = await import("./native.js");
+      const configDir = path.join(serverRoot(updated, ctxOf(updated)), "Pal", "Saved", "Config", process.platform === "win32" ? "WindowsServer" : "LinuxServer");
+      fs.mkdirSync(configDir, { recursive: true });
+      fs.writeFileSync(path.join(configDir, "PalWorldSettings.ini"), renderPalWorldSettingsIni(updated.settings));
+    }
     return { applied: "on-next-restart", settings: updated.settings };
   });
 

--- a/packages/agent/src/store.ts
+++ b/packages/agent/src/store.ts
@@ -44,6 +44,9 @@ const STORE_FILE = path.join(DATA_DIR, "instances.json");
 /** Steam 查詢埠的分配起點(Palworld 預設值);往上遞增找沒被占用的。 */
 const QUERY_PORT_BASE = 27015;
 
+/** REST API 埠的分配起點(Palworld 預設值);往上遞增找沒被占用的。 */
+const REST_PORT_BASE = 8212;
+
 /**
  * Flat-file store for instance metadata. Container state lives in Docker
  * (labels + inspect); this file is the source of truth for settings only.
@@ -89,6 +92,19 @@ export class InstanceStore {
       this.list().map((r) => r.queryPort).filter((p): p is number => !!p),
     );
     let port = QUERY_PORT_BASE;
+    while (used.has(port)) port++;
+    return port;
+  }
+
+  /** 分配一個沒被別台占用的 REST API 埠(建立實例時用);只計算已啟用 REST 的實例。 */
+  nextRestApiPort(): number {
+    const used = new Set(
+      this
+        .list()
+        .filter((r) => r.settings.RESTAPIEnabled)
+        .map((r) => r.settings.RESTAPIPort),
+    );
+    let port = REST_PORT_BASE;
     while (used.has(port)) port++;
     return port;
   }


### PR DESCRIPTION
Closes #26

## 變更摘要

### REST API port 1:1 映射
- **docker.ts**：container+host port 都讀 `RESTAPIPort`（1:1，同 queryPort 模式）；移除 `restHostPort()`
- **restapi.ts**：docker baseUrl() 直接用 `RESTAPIPort`；移除 dockerOps import
- **store.ts**：加 `nextRestApiPort()` 自動分配（只算啟用實例）

### native settings 即時寫 ini
- **routes.ts**：settings PUT 對 native 即時寫 `PalWorldSettings.ini`（跟 docker 一致）

### 鏡像伺服器 port 衝突檢測
- **routes.ts `/duplicate`**：複製實例時自動分配 RESTAPIPort（不再沿用來源）
- **routes.ts settings PUT**：補 PublicPort (game port) + RCONPort 衝突檢測
- **routes.ts 建立/settings PUT**：所有 backend（含 k8s）統一 port 衝突檢測，確保外部連線 1:1 映射正確，每實例 port 唯一

## 注意事項

既有 docker 實例的容器仍綁 ephemeral port，升級後需手動 stop → remove → start 一次。