### PR TITLE
feat: 伺服器端目錄瀏覽器、自訂帕魯濃縮 UI 快速選取、pgbroadcast 改走 REST API、頭目 ID 顯示修復

### DIFF
--- a/packages/agent/src/routes.ts
+++ b/packages/agent/src/routes.ts
@@ -25,6 +25,7 @@ import {
   type InstanceSummary,
   type KnownPlayer,
   type RconCommandsResponse,
+  type DirEntry,
 } from "@palserver/shared";
 import { fetchServerCommands, rconExec, requireRcon } from "./rcon.js";
 import type { PresenceTracker } from "./presence.js";
@@ -1753,6 +1754,83 @@ export function registerRoutes(
     if (srcRec.id === dstRec.id) throw Object.assign(new Error("不能鏡像到自己"), { statusCode: 409 });
     const result = await saves.mirrorWorld(srcRec, ctxOf(srcRec), dstRec, ctxOf(dstRec));
     return { mirrored: true, worldGuid: result.worldGuid, targetId: dstRec.id };
+  });
+
+  // ── host directory browser (for server path picker in create dialog) ──
+  const HostDirQuery = z.object({ path: z.string().max(1000).default("") });
+
+  /** 列出 Windows 上所有可用的磁碟機代號。 */
+  function listDrives(): DirEntry[] {
+    const drives: DirEntry[] = [];
+    for (let i = 65; i <= 90; i++) {
+      const letter = String.fromCharCode(i);
+      const root = `${letter}:\\`;
+      try {
+        fs.accessSync(root, fs.constants.F_OK);
+        drives.push({
+          name: root,
+          isDir: true,
+          size: 0,
+          modifiedAt: "",
+          editable: false,
+        });
+      } catch {
+        // 不存在的磁碟機
+      }
+    }
+    return drives;
+  }
+
+  app.get("/api/host/list-dir", async (req) => {
+    const { path: dirPath } = HostDirQuery.parse(req.query);
+    const target = dirPath.trim();
+
+    // Windows: 空路徑 → 列出所有可用磁碟機
+    if (!target && process.platform === "win32") {
+      return { path: "", entries: listDrives() };
+    }
+
+    const resolved = target ? path.resolve(target) : "/";
+    if (target && !path.isAbsolute(target)) {
+      throw Object.assign(new Error("請輸入絕對路徑"), { statusCode: 400 });
+    }
+    const stat = fs.statSync(resolved, { throwIfNoEntry: false });
+    if (!stat) throw Object.assign(new Error("路徑不存在"), { statusCode: 404 });
+    if (!stat.isDirectory()) throw Object.assign(new Error("不是資料夾"), { statusCode: 400 });
+    const entries: DirEntry[] = fs
+      .readdirSync(resolved, { withFileTypes: true })
+      .flatMap((entry) => {
+        try {
+          const full = path.join(resolved, entry.name);
+          const s = fs.statSync(full, { throwIfNoEntry: false });
+          if (!s) return [];
+          return {
+            name: entry.name,
+            isDir: entry.isDirectory(),
+            size: s.size,
+            modifiedAt: new Date(s.mtimeMs).toISOString(),
+            editable: false,
+          } satisfies DirEntry;
+        } catch {
+          return []; // 跳過權限不足或無法存取的項目 (如 DumpStack.log.tmp)
+        }
+      })
+      .sort((a, b) => (a.isDir === b.isDir ? a.name.localeCompare(b.name) : a.isDir ? -1 : 1));
+    return { path: resolved, entries };
+  });
+
+  app.post("/api/host/mkdir", async (req, reply) => {
+    const { path: dirPath } = z.object({ path: z.string().min(1).max(1000) }).parse(req.body);
+    if (!path.isAbsolute(dirPath)) {
+      throw Object.assign(new Error("請輸入絕對路徑"), { statusCode: 400 });
+    }
+    const resolved = path.resolve(dirPath);
+    if (fs.existsSync(resolved)) {
+      throw Object.assign(new Error("路徑已存在"), { statusCode: 409 });
+    }
+    fs.mkdirSync(resolved, { recursive: true });
+    reply.code(201);
+    return { created: resolved };
   });
 
   // ── file browser (native server root or k8s /palworld root) ──

--- a/packages/shared/src/commands.ts
+++ b/packages/shared/src/commands.ts
@@ -89,13 +89,6 @@ export const COMMANDS: CommandSpec[] = [
   { name: "ShowPlayers", source: "builtin", category: "players", label: "列出所有在線玩家", args: [] },
   { name: "Save", source: "builtin", category: "server", label: "儲存世界資料", args: [] },
   {
-    name: "Broadcast",
-    source: "builtin",
-    category: "server",
-    label: "廣播訊息(內建指令不支援空白字元)",
-    args: [{ name: "message", label: "訊息", required: true, placeholder: "Hello_everyone" }],
-  },
-  {
     name: "Shutdown",
     source: "builtin",
     category: "server",
@@ -121,7 +114,7 @@ export const COMMANDS: CommandSpec[] = [
     name: "pgbroadcast",
     source: "paldefender",
     category: "server",
-    label: "廣播訊息(支援空白字元)",
+    label: "廣播訊息(支援中文)",
     args: [{ name: "message", label: "訊息", required: true, placeholder: "伺服器將在 5 分鐘後重啟" }],
   },
   {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -125,8 +125,8 @@ export const CustomPalSchema = z
     })
     .optional(),
   /** 濃縮消耗隻數(PalDefender CondensedPals 吃數量,不是星星等級)。
-   *  滿星(4★)實際需要 116 隻;上限 999 與 UI 的 max 一致,擋荒謬值。 */
-  condensedPals: z.number().int().min(0).max(999).optional(),
+   *  當前版本滿濃縮需 48 隻。 */
+  condensedPals: z.number().int().min(0).max(48).optional(),
   /** 靈魂強化,每項 0–20。 */
   souls: z
     .object({

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { GiSheep, GiEggClutch } from "react-icons/gi";
-import { FiActivity, FiAlertTriangle, FiClock, FiCpu, FiDownload, FiHardDrive, FiHeart, FiHelpCircle, FiPlus, FiServer, FiSettings, FiStar, FiUsers, FiZap } from "react-icons/fi";
+import { FiActivity, FiAlertTriangle, FiClock, FiCpu, FiDownload, FiFolder, FiHardDrive, FiHeart, FiHelpCircle, FiPlus, FiServer, FiSettings, FiStar, FiUsers, FiZap } from "react-icons/fi";
 import { hasFeature } from "@palserver/shared";
 import type { Backend, ExternalWorldCandidate, InstanceStats, InstanceSummary, LiveStatus } from "@palserver/shared";
 import {
@@ -28,6 +28,7 @@ import { SettingsModal } from "./SettingsModal";
 import { CreditsModal } from "./CreditsModal";
 import { InstanceDetailPage } from "./InstanceDetail";
 import { Mascot } from "./Mascot";
+import { DirectoryPicker } from "./DirectoryPicker";
 import { AnnouncementPopup } from "./AnnouncementModal";
 import { ImportSaveModal } from "./ImportSaveModal";
 import { OPEN_SETTINGS_EVENT, SiteFooter } from "./SiteFooter";
@@ -545,6 +546,8 @@ function CreateDialog({
   const [platform, setPlatform] = useState<string | null>(null);
   const [availableBackends, setAvailableBackends] = useState<Backend[]>(["native"]);
   const [advancedMode, setAdvancedMode] = useState(false);
+  const [showDirPicker, setShowDirPicker] = useState(false);
+
   // k8s 是把伺服器跑在叢集裡(agent 只是遙控),所以 agent 這台是不是 macOS 無所謂。
   const isMac = platform === "darwin" && backend !== "k8s";
   const k8sIncomplete = backend === "k8s" && (!k8sNamespace.trim() || !k8sStatefulSet.trim());
@@ -726,20 +729,41 @@ function CreateDialog({
         {backend === "native" && (
           <label className={labelCls}>
             {t("伺服器路徑(選填)")}
-            <input
-              className={inputCls}
-              value={serverDir}
-              onChange={(e) => setServerDir(e.target.value)}
-              placeholder={
-                platform === "win32"
-                  ? t("例:{path}", { path: "D:\\palworld\\my-server" })
-                  : t("例:{path}", { path: "/opt/palworld/my-server" })
-              }
-            />
+            <div className="flex gap-2">
+              <input
+                className={`${inputCls} flex-1`}
+                value={serverDir}
+                onChange={(e) => setServerDir(e.target.value)}
+                placeholder={
+                  platform === "win32"
+                    ? t("例:{path}", { path: "D:\\palworld\\my-server" })
+                    : t("例:{path}", { path: "/opt/palworld/my-server" })
+                }
+              />
+              <button
+                type="button"
+                className={`${btnGhost} inline-flex items-center gap-1.5 px-3`}
+                onClick={() => setShowDirPicker(true)}
+                title={t("瀏覽資料夾")}
+              >
+                <FiFolder className="size-4" />
+              </button>
+            </div>
             <span className="text-xs font-normal opacity-70">
               {t("留空 = 安裝到 agent 資料夾。填既有 PalServer 安裝目錄會直接採用;填空資料夾或新路徑則會下載安裝到那裡。")}
             </span>
           </label>
+        )}
+        {showDirPicker && (
+          <DirectoryPicker
+            client={client}
+            initialPath={serverDir}
+            onSelect={(path) => {
+              setServerDir(path);
+              setShowDirPicker(false);
+            }}
+            onClose={() => setShowDirPicker(false)}
+          />
         )}
         <label className={labelCls}>
           {t("遊戲埠(UDP)")}

--- a/packages/web/src/ConsoleTab.tsx
+++ b/packages/web/src/ConsoleTab.tsx
@@ -273,8 +273,15 @@ export function ConsoleTab({
     setBusy(true);
     setError(null);
     try {
-      const res = await client.rconExec(instanceId, command);
-      setLog((prev) => [...prev.slice(-99), { command, output: res.output || t("(無輸出)"), failed: false }]);
+      // pgbroadcast 不走 RCON，改走 REST API 以支援中文
+      if (command.startsWith("pgbroadcast ")) {
+        const message = command.slice("pgbroadcast ".length);
+        await client.announce(instanceId, message);
+        setLog((prev) => [...prev.slice(-99), { command: message, output: t("已發送"), failed: false }]);
+      } else {
+        const res = await client.rconExec(instanceId, command);
+        setLog((prev) => [...prev.slice(-99), { command, output: res.output || t("(無輸出)"), failed: false }]);
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       setLog((prev) => [...prev.slice(-99), { command, output: message, failed: true }]);
@@ -439,6 +446,7 @@ export function ConsoleTab({
 
         {/* 工作區:選定指令的參數 + 唯一輸入列 + 輸出(有內容才出現) */}
         <div className="flex min-h-0 flex-col gap-3">
+
           {selected && selected.args.length > 0 && (
             <div className="flex shrink-0 flex-col gap-3 rounded-cute border-2 border-line p-3">
               <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">

--- a/packages/web/src/CustomPalModal.tsx
+++ b/packages/web/src/CustomPalModal.tsx
@@ -338,9 +338,47 @@ export function CustomPalModal({
             </div>
           </div>
 
-          <div className="grid gap-2 sm:grid-cols-4">
-            {/* 改為濃縮隻數,因 PalDefender CondensedPals 吃消耗數量而非星等;max 對應 schema 已放寬。 */}
-            {numField(t("濃縮隻數"), stars, setStars, 999)}
+          <div>
+            <div className="mb-1 grid gap-2 sm:grid-cols-5">
+              <label className="flex min-w-0 flex-col gap-1 text-xs font-bold text-ink-muted">
+                {t("濃縮隻數")}
+                <input
+                  className={inputCls}
+                  type="number"
+                  min={0}
+                  max={48}
+                  value={stars}
+                  placeholder="—"
+                  onChange={(e) => setStars(e.target.value)}
+                />
+              </label>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {[
+                { stars: 0, count: 0, label: "☆0" },
+                { stars: 1, count: 4, label: "☆1" },
+                { stars: 2, count: 12, label: "☆2" },
+                { stars: 3, count: 24, label: "☆3" },
+                { stars: 4, count: 48, label: "☆4" },
+              ].map((s) => (
+                <button
+                  key={s.stars}
+                  type="button"
+                  className={`rounded-full border-2 px-3 py-1 text-xs font-bold transition ${
+                    Number(stars) === s.count
+                      ? "border-pal bg-pal text-white"
+                      : "border-line bg-card-soft text-ink hover:border-pal"
+                  }`}
+                  onClick={() => setStars(String(s.count))}
+                >
+                  <FiStar className={`mr-1 inline size-3 ${s.stars === 0 ? "opacity-30" : ""}`} />
+                  {s.label}
+                </button>
+              ))}
+            </div>
+            <p className="mt-1 text-[11px] text-ink-muted">
+              {t("按星等快速填入累積濃縮數量，也可直接手動輸入。")}
+            </p>
           </div>
 
           <div>

--- a/packages/web/src/DirectoryPicker.tsx
+++ b/packages/web/src/DirectoryPicker.tsx
@@ -1,0 +1,249 @@
+import { useCallback, useEffect, useState } from "react";
+import { FiChevronRight, FiFolder, FiFolderPlus, FiRefreshCw, FiArrowUpCircle } from "react-icons/fi";
+import type { DirEntry } from "@palserver/shared";
+import type { AgentClient } from "./api";
+import { t, useI18n } from "./i18n";
+import { btn, btnGhost, card, errorCls, inputCls } from "./ui";
+
+/** 路徑分隔符:偵測是 Windows 風格(\\) 還是 Unix 風格(/)。 */
+function sepOf(p: string): string {
+  return p.includes("\\") ? "\\" : "/";
+}
+
+/** 絕對路徑的 parent。Windows 上從 C:\Users 回到 C:\，從 C:\ 回到 ""（磁碟機列表）。 */
+function parentDir(p: string): string {
+  const s = sepOf(p);
+  const clean = p.replace(/[/\\]$/, "");
+  const parts = clean.split(/[/\\]+/);
+  if (parts.length <= 1) return ""; // 根目錄或磁碟機 → 回到最上層
+  const up = parts.slice(0, -1).join(s);
+  // Windows: 如果 parent 只剩磁碟代號(如 C:)，補上反斜線
+  return /^[A-Za-z]:$/.test(up) ? up + "\\" : up;
+}
+
+/** 讓使用者在 agent 主機上瀏覽目錄、選取一個資料夾路徑。 */
+export function DirectoryPicker({
+  client,
+  initialPath = "",
+  onSelect,
+  onClose,
+}: {
+  client: AgentClient;
+  initialPath?: string;
+  onSelect: (path: string) => void;
+  onClose: () => void;
+}) {
+  useI18n();
+  const [currentPath, setCurrentPath] = useState(initialPath);
+  const [entries, setEntries] = useState<DirEntry[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [manualPath, setManualPath] = useState("");
+
+  const refresh = useCallback(async (path: string) => {
+    setError(null);
+    setEntries(null);
+    setBusy(true);
+    try {
+      const res = await client.hostListDir(path);
+      setCurrentPath(res.path);
+      setEntries(res.entries);
+      setManualPath(res.path);
+    } catch (err) {
+      setEntries([]);
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [client]);
+
+  useEffect(() => {
+    if (initialPath) void refresh(initialPath);
+    else void refresh("");
+  }, []); // only on mount
+
+  const isWin =
+    currentPath.includes("\\") || /^[A-Za-z]:/.test(currentPath);
+
+  const goUp = () => {
+    if (!currentPath) return; // 已在最上層
+    const parent = parentDir(currentPath);
+    void refresh(parent);
+  };
+
+  const goTo = (name: string) => {
+    if (!currentPath) {
+      // 從磁碟機列表進入
+      void refresh(name);
+    } else {
+      const s = sepOf(currentPath);
+      const next = currentPath.replace(/[/\\]$/, "") + s + name;
+      void refresh(next);
+    }
+  };
+
+  const handleManualGo = () => {
+    if (manualPath.trim()) void refresh(manualPath.trim());
+  };
+
+  const handleNewFolder = async () => {
+    if (!currentPath) return;
+    const name = prompt(t("新資料夾名稱"));
+    if (!name?.trim()) return;
+    setBusy(true);
+    try {
+      const s = sepOf(currentPath);
+      const fullPath = currentPath.replace(/[/\\]$/, "") + s + name.trim();
+      await client.hostMkdir(fullPath);
+      await refresh(currentPath);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setBusy(false);
+    }
+  };
+
+  const segments = currentPath
+    ? currentPath
+        .replace(/\\/g, "/")
+        .replace(/\/+/g, "/")
+        .replace(/\/$/, "")
+        .split("/")
+    : [];
+
+  return (
+    <div
+      className="fixed inset-0 z-10 flex items-start justify-center overflow-y-auto bg-[rgb(35_32_48/0.55)] p-6 backdrop-blur-[3px]"
+      onClick={onClose}
+    >
+      <div
+        className={`${card} my-auto flex max-h-[90vh] w-[600px] max-w-full flex-col gap-3 overflow-y-auto`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="inline-flex items-center gap-2 text-lg font-extrabold">
+            <FiFolder className="size-5 text-pal" /> {t("選擇資料夾")}
+          </h2>
+          <button className={btnGhost} onClick={onClose}>
+            {t("關閉")}
+          </button>
+        </div>
+
+        {/* 手動輸入/顯示路徑 */}
+        <div className="flex gap-2">
+          <input
+            className={`${inputCls} flex-1 font-mono text-xs`}
+            value={manualPath}
+            onChange={(e) => setManualPath(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleManualGo();
+            }}
+            placeholder={t("絕對路徑，或留空顯示根目錄")}
+          />
+          <button
+            type="button"
+            className={`${btnGhost} inline-flex items-center gap-1.5 px-3`}
+            onClick={handleManualGo}
+            disabled={busy}
+            title={t("前往")}
+          >
+            <FiChevronRight className="size-4" />
+          </button>
+        </div>
+
+        {/* 麵包屑導航 */}
+        <nav className="flex flex-wrap items-center gap-1 text-[13px] font-bold">
+          {!currentPath ? (
+            <span className="flex items-center gap-1 text-ink">
+              <FiFolder className="size-3.5" />
+              <span>{isWin ? t("本機") : "/"}</span>
+            </span>
+          ) : (
+            <>
+              <button className="flex items-center gap-1 text-pal hover:underline" onClick={goUp} title={t("上一層")}>
+                <FiArrowUpCircle className="size-4" />
+              </button>
+              {segments.map((seg, i) => (
+                <span key={i} className="flex items-center gap-1">
+                  <FiChevronRight className="size-3.5 text-ink-muted" />
+                  <button
+                    className={
+                      i === segments.length - 1 ? "text-ink" : "text-pal hover:underline"
+                    }
+                    onClick={() => {
+                      if (i < segments.length - 1) {
+                        let up = segments.slice(0, i + 1).join("/");
+                        // Windows: 轉換 C: 成 C:\
+                        if (isWin) up = up.replace(/^([A-Za-z]):$/, "$1:\\");
+                        void refresh(up);
+                      }
+                    }}
+                  >
+                    {seg}
+                  </button>
+                </span>
+              ))}
+            </>
+          )}
+        </nav>
+
+        {/* 錯誤 */}
+        {error && <p className={errorCls}>{error}</p>}
+
+        {/* 目錄列表 */}
+        <div className={`${card} max-h-[50vh] overflow-y-auto p-0`}>
+          {entries === null ? (
+            <p className="p-5 text-[13px] text-ink-muted">{t("載入中…")}</p>
+          ) : entries.filter((e) => e.isDir).length === 0 ? (
+            <p className="p-5 text-[13px] text-ink-muted">{t("這個資料夾沒有子資料夾。")}</p>
+          ) : (
+            <div className="flex flex-col divide-y divide-line">
+              {entries
+                .filter((e) => e.isDir)
+                .map((entry) => (
+                  <button
+                    key={entry.name}
+                    className="flex items-center gap-3 px-4 py-2.5 text-left transition hover:bg-card-soft"
+                    onClick={() => goTo(entry.name)}
+                  >
+                    <FiFolder className="size-4 shrink-0 text-pal" />
+                    <span className="flex-1 truncate text-sm font-bold">{entry.name}</span>
+                    <span className="text-xs text-ink-muted">{t("資料夾")}</span>
+                  </button>
+                ))}
+            </div>
+          )}
+        </div>
+
+        {/* 選取按鈕 */}
+        <div className="flex gap-2">
+          <button
+            className={`${btn} flex-1`}
+            onClick={() => onSelect(currentPath)}
+            disabled={busy || !!error}
+          >
+            {t("選取此資料夾")}
+          </button>
+          {currentPath && (
+            <button
+              type="button"
+              className={`${btnGhost} inline-flex items-center gap-1.5`}
+              onClick={handleNewFolder}
+              disabled={busy}
+              title={t("在當前目錄建立新資料夾")}
+            >
+              <FiFolderPlus className="size-4" /> {t("新資料夾")}
+            </button>
+          )}
+          <button
+            type="button"
+            className={`${btnGhost} inline-flex items-center gap-1.5`}
+            onClick={() => void refresh(currentPath)}
+            disabled={busy}
+          >
+            <FiRefreshCw className="size-4" /> {t("重新整理")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/api.ts
+++ b/packages/web/src/api.ts
@@ -832,6 +832,17 @@ export class AgentClient {
     return this.request(`/api/instances/${id}/logs/sources`);
   }
 
+  hostListDir(path: string): Promise<{ path: string; entries: DirEntry[] }> {
+    return this.request(`/api/host/list-dir?path=${encodeURIComponent(path)}`);
+  }
+
+  hostMkdir(path: string): Promise<{ created: string }> {
+    return this.request("/api/host/mkdir", {
+      method: "POST",
+      body: JSON.stringify({ path }),
+    });
+  }
+
   logsSocket(id: string, source: LogSourceId = "agent"): WebSocket {
     const wsUrl = this.conn.url.replace(/^http/, "ws");
     return new WebSocket(

--- a/packages/web/src/gameData.ts
+++ b/packages/web/src/gameData.ts
@@ -66,7 +66,8 @@ export interface CharacterHit {
 }
 
 /** 依存檔/REST 的 CharacterID 查「帕魯或人類 NPC」:
- *  大小寫寬鬆、BOSS_ 前綴自動剝除;帕魯圖鑑優先,再查人類 NPC 目錄。 */
+ *  大小寫寬鬆、BOSS_ 前綴自動剝除;帕魯圖鑑優先,再查人類 NPC 目錄。
+ *  若完全找不到,會嘗試去尾綴(Boss001 等)後回退成自訂實體。 */
 export function findCharacter(d: GameData | null, id: string): CharacterHit | undefined {
   if (!d || !id) return undefined;
   const bare = id.replace(/^BOSS_/i, "");
@@ -78,7 +79,22 @@ export function findCharacter(d: GameData | null, id: string): CharacterHit | un
   if (pal) return { entity: pal, iconUrl: pal.icon ? palIconUrl(pal.icon) : undefined };
   const human = d.humanByIdLower.get(id.toLowerCase()) ?? d.humanByIdLower.get(bare.toLowerCase());
   if (human) return { entity: human, iconUrl: human.icon ? humanIconUrl(human.icon) : undefined };
-  return undefined;
+  // 目錄中找不到：剝除尾綴(如 YakushimaBoss001 → Yakushima)再試一次
+  const cleaned = id.replace(/[Bb]oss\d*$/, "").replace(/\d+$/, "");
+  if (cleaned && cleaned !== id) {
+    const pal2 =
+      d.palById.get(cleaned) ??
+      d.palByIdLower.get(cleaned.toLowerCase());
+    if (pal2) return { entity: pal2, iconUrl: pal2.icon ? palIconUrl(pal2.icon) : undefined };
+    const human2 = d.humanByIdLower.get(cleaned.toLowerCase());
+    if (human2) return { entity: human2, iconUrl: human2.icon ? humanIconUrl(human2.icon) : undefined };
+  }
+  // 真的找不到：回退成自訂實體，至少顯示一個可讀名稱
+  const fallbackName = cleaned || id.replace(/_\d+$/, "");
+  return {
+    entity: { id, name: fallbackName },
+    iconUrl: undefined,
+  };
 }
 
 const REMOTE_BASE =

--- a/scripts/sync-upstream.ps1
+++ b/scripts/sync-upstream.ps1
@@ -1,0 +1,58 @@
+# palserver GUI - 同步上游更新腳本
+# 用法: 在 repo 任意位置執行  .\scripts\sync-upstream.ps1
+# 做的事: 拉 upstream 最新程式碼 -> 合併 -> 安裝依賴 -> typecheck
+#
+# 確保有設 upstream remote:
+#   git remote add upstream https://github.com/io-software-ai/palserver-gui.git
+
+$ErrorActionPreference = "Stop"
+Set-Location (Join-Path $PSScriptRoot "..")
+
+$before = (git rev-parse --short HEAD)
+Write-Host "[目前版本] $before" -ForegroundColor DarkGray
+
+# 確認現在在 main 分支
+$branch = (git rev-parse --abbrev-ref HEAD)
+if ($branch -ne "main") {
+  Write-Host "[錯誤] 請先切到 main 分支 (git checkout main) 再同步" -ForegroundColor Red
+  exit 1
+}
+
+# 像 update.ps1 一樣處理漂移
+$drift = (git status --porcelain -- package.json pnpm-lock.yaml)
+if ($drift) {
+  Write-Host "[修正] package.json / pnpm-lock.yaml 有本機漂移, 還原 ..." -ForegroundColor Yellow
+  git checkout -- package.json pnpm-lock.yaml
+}
+
+$dirty = (git status --porcelain)
+if ($dirty) {
+  Write-Host "[警告] 本機仍有未提交改動:" -ForegroundColor Yellow
+  Write-Host $dirty
+  Write-Host "請先  git stash  暫存或提交後再同步。" -ForegroundColor Yellow
+  exit 1
+}
+
+Write-Host "[1/4] git fetch upstream ..." -ForegroundColor Cyan
+git fetch upstream
+
+Write-Host "[2/4] git merge upstream/main ..." -ForegroundColor Cyan
+git merge upstream/main --no-edit
+
+Write-Host "[3/4] pnpm install ..." -ForegroundColor Cyan
+pnpm install
+
+Write-Host "[4/4] pnpm typecheck ..." -ForegroundColor Cyan
+pnpm typecheck
+
+$after = (git rev-parse --short HEAD)
+Write-Host ""
+Write-Host "==================== 同步結果 ====================" -ForegroundColor Green
+Write-Host ("  版本:  {0}  ->  {1}" -f $before, $after)
+if ($before -eq $after) {
+  Write-Host "  已是最新, 無更新。" -ForegroundColor Yellow
+}
+Write-Host "=================================================" -ForegroundColor Green
+Write-Host ""
+Write-Host "接著推送你的 fork:" -ForegroundColor Cyan
+Write-Host ("  git push origin main") -ForegroundColor White


### PR DESCRIPTION
## 摘要

建立伺服器時可瀏覽 agent 主機上的目錄結構選取路徑（取代無法取得絕對路徑的瀏覽器端 webkitdirectory），自訂帕魯濃縮輸入加入星等快速選取，pgbroadcast 指令改走 REST API 以支援中文，修復玩家詳細資訊中部分頭目 ID 無法正常顯示名稱的問題。

## 新功能

### 伺服器端目錄瀏覽器

**修改**:

- `packages/agent/src/routes.ts`:
  - 新增 `GET /api/host/list-dir?path=<絕對路徑>` — 利用 Node.js `fs.readdirSync` 直接列出 agent 主機上的目錄內容
  - Windows 上路徑為空時自動掃描 A:～Z: 回傳所有可用磁碟機（透過 `fs.accessSync` 檢測）
  - 遇到 `DumpStack.log.tmp` 等權限不足的系統檔案時以 `try/catch` 跳過，不讓整個請求失敗
  - 新增 `POST /api/host/mkdir` — 在 agent 主機上建立新資料夾（絕對路徑），供 DirectoryPicker 的「新資料夾」功能使用
  - 所有端點受 agent 既有的 `onRequest` auth hook 保護

- `packages/web/src/api.ts`:
  - 新增 `hostListDir(path)` — 呼叫 `/api/host/list-dir`
  - 新增 `hostMkdir(path)` — 呼叫 `/api/host/mkdir`

- `packages/web/src/DirectoryPicker.tsx`（新檔案）:
  - 模態視窗元件，透過 agent API 瀏覽主機目錄結構
  - Windows 上預設顯示所有磁碟機（C:、D:、E:⋯），點擊進入該磁碟根目錄
  - 麵包屑導航：可點擊任一路徑層級跳轉，附「上一層」按鈕
  - 頂部可手動輸入/編輯路徑，按 Enter 或 → 按鈕前往
  - 「新資料夾」按鈕：彈出 prompt 輸入名稱，建立後自動重新整理列表
  - 「選取此資料夾」按鈕：將目前瀏覽的路徑填入建立伺服器表單
  - 沿用專案 Tailwind 設計風格（與 FileManager 一致）

- `packages/web/src/App.tsx`:
  - 移除 `useRef` + `webkitdirectory` 的瀏覽器端 hack（`dirInputRef`、`handleBrowseDir`、`handleDirSelected`）
  - 新增 `showDirPicker` 狀態控制 DirectoryPicker 顯示
  - 資料夾圖示按鈕改為開啟 DirectoryPicker，選取後透過 `onSelect` callback 將完整絕對路徑填入 `serverDir`

### 自訂帕魯濃縮 UI 快速選取

**問題**: 濃縮數量欄位只有單純的數字輸入框，使用者需自行查閱各星等所需的累積濃縮數量，不熟悉數字的玩家不易使用。

**修改**:

- `packages/web/src/CustomPalModal.tsx`:
  - 濃縮欄位改為數字輸入框（保留手動輸入能力）+ 5 個星等快速按鈕
  - 星等按鈕（☆0–☆4）點選自動填入該星等對應的累積濃縮數量
  - 選中的按鈕以 filled 樣式高亮顯示
  - 累積值對照: ☆0=0 / ☆1=4 / ☆2=12 / ☆3=24 / ☆4=48
  - 新增底部提示文字：「按星等快速填入累積濃縮數量，也可直接手動輸入。」

## 錯誤修正

### 濃縮數量上限與遊戲版本不一致

**問題**: 上次提交時先設定了極高值 `condensedPals` schema 上限設為 999，但當前遊戲版本滿濃縮僅需 48 隻，因此做補交修改成目前版本的數量。

**修改**:

- `packages/shared/src/index.ts`: `z.number().int().min(0).max(999)` → `max(48)`，註解同步更新為「當前版本滿濃縮需 48 隻」

### 玩家詳細資訊頭目 ID 無法顯示

**問題**: 玩家詳細資訊中 `YakushimaBoss001` 等頭目/事件實體 ID 不在 `pals.json` 帕魯圖鑑目錄中，`findCharacter` 回傳 `undefined`，UI 退而顯示原始 ID 字串（如 `YakushimaBoss001`）。

**修改**:

- `packages/web/src/gameData.ts`: `findCharacter` 函數新增三層回退機制:
  1. 既有邏輯（大小寫寬鬆、`BOSS_` 前綴剝除）— 不變
  2. 剝除 `Boss001`、`boss` 等尾綴後再查圖鑑 — 例如 `WeaselDragonBoss001` 可正確對應到「疾旋鼬」
  3. 完全找不到時建立合成 `GameEntity`，以清理後的名稱顯示（`YakushimaBoss001` → `Yakushima`）
  - 無對應圖示時顯示 `FiUser` 人形佔位圖

## 重構

### pgbroadcast 改走 REST API

**問題**: `pgbroadcast` 指令原本走 RCON 發送，但 RCON 協定對非 ASCII 字元的編碼支援有限，導致中文訊息變成亂碼。且在 issues #30 有看到目前的 RCON 將被放棄，因此修改成 REST API。

**修改**:

- `packages/web/src/ConsoleTab.tsx`:
  - `run()` 函數判斷指令以 `pgbroadcast ` 開頭時，改呼叫 `client.announce(instanceId, message)`（REST API `/announce`，全程 UTF-8 JSON），不再走 `client.rconExec()`
  - 移除獨立的「廣播訊息」區塊（state、handler、JSX）— 不再需要，功能已整合進指令系統
  - 移除 `FiSend` 圖示 import
  - 日誌顯示改為只顯示訊息內容（不含指令前綴），輸出顯示「已發送」

- `packages/shared/src/commands.ts`:
  - 移除內建 `Broadcast` 指令（不支援空白字元，中文無法使用），避免使用者混淆
  - `pgbroadcast` 標籤從「廣播訊息(支援空白字元)」改為「廣播訊息(支援中文)」

## 修改的檔案

```
packages/agent/src/routes.ts
packages/shared/src/commands.ts
packages/shared/src/index.ts
packages/web/src/App.tsx
packages/web/src/ConsoleTab.tsx
packages/web/src/CustomPalModal.tsx
packages/web/src/DirectoryPicker.tsx (new)
packages/web/src/api.ts
packages/web/src/gameData.ts
packages/web/public/i18n/en.json
packages/web/public/i18n/ja.json
```

## 備註

- DirectoryPicker 所有請求透過 agent API，受 `app.addHook("onRequest")` 的 auth 機制保護（/public endoints 除外）
- 濃縮數量 4/12/24/48 為當前遊戲版本的累積值，若未來版本改動需對應更新 schema 上限與 UI 按鈕數值
- `pgbroadcast` 改走 REST API 後依賴遊戲的 REST API 端點（預設埠 8212），需確認伺服器已啟用 REST API