### PR TITLE
feat: 統一 backend 語意與分離管理端能力

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,5 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
+      - run: pnpm test
       - run: pnpm build

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev:web": "pnpm build:shared && pnpm --filter @palserver/web dev",
     "build": "pnpm -r build",
     "typecheck": "pnpm build:shared && pnpm -r typecheck",
+    "test": "pnpm build:shared && pnpm -r --if-present test",
     "bundle:agent": "pnpm build:shared && pnpm --filter @palserver/agent build && node scripts/bundle-agent.mjs",
     "release:exe": "pnpm build:shared && pnpm --filter @palserver/web build && pnpm bundle:agent && node scripts/build-sea.mjs"
   },

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -11,6 +11,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "tsx --test src/*.test.ts",
     "start": "node dist/index.js"
   },
   "dependencies": {

--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -1,0 +1,107 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import cors from "@fastify/cors";
+import websocket from "@fastify/websocket";
+import fastifyStatic from "@fastify/static";
+import { ZodError } from "zod";
+import { registerRoutes } from "./routes.js";
+import { WEB_ORIGINS, REQUIRE_TOKEN } from "./env.js";
+import { isLoopback, makeAuthHook } from "./auth.js";
+import type { InstanceStore } from "./store.js";
+import type { PresenceTracker } from "./presence.js";
+import type { BackupScheduler } from "./backup-scheduler.js";
+import type { RestartSupervisor } from "./supervisor.js";
+import type { AuthContext } from "./auth.js";
+import type { UpdateOps } from "./self-update.js";
+import type { TlsCert } from "./tls.js";
+import type { PublicMapPublisher } from "./public-map.js";
+
+/** App 建構需要的 deps(生產與測試共用)。 */
+export interface AppDeps {
+  store: InstanceStore;
+  presence: PresenceTracker;
+  scheduler: BackupScheduler;
+  supervisor: RestartSupervisor;
+  publicMap: PublicMapPublisher;
+  auth: AuthContext;
+  updateOps: UpdateOps;
+}
+
+export interface AppOptions extends AppDeps {
+  /** TLS 憑證;測試不傳(走 http)。 */
+  tls?: TlsCert | null;
+  /** 內建前端 dist 目錄;測試不傳(不伺服前端)。 */
+  webDist?: string | null;
+}
+
+/**
+ * 建構 Fastify app:fastify 建構 + 中性 middleware(cors/static/websocket/
+ * errorHandler)+ auth hook + registerRoutes。
+ *
+ * 生產與測試共用此 factory(routes.test.ts 用 mock deps 呼叫它)。
+ * Lifecycle side effects(presence.start / scheduler.start / announceBoot /
+ * app.listen 等)留給呼叫端,不在此處。
+ */
+export async function createApp(opts: AppOptions): Promise<FastifyInstance> {
+  const app = Fastify({
+    logger: { level: "warn" },
+    bodyLimit: 1024 * 1024 * 1024,
+    ...(opts.tls ? { https: { key: opts.tls.key, cert: opts.tls.cert } } : {}),
+  });
+
+  app.addContentTypeParser("application/octet-stream", (_req, _payload, done) => done(null, undefined));
+
+  await app.register(cors, {
+    origin(origin, cb) {
+      if (!origin) return cb(null, true);
+      let host = "";
+      try {
+        host = new URL(origin).hostname;
+      } catch {
+        return cb(null, false);
+      }
+      if (host === "localhost" || host === "127.0.0.1" || host === "::1") return cb(null, true);
+      if (WEB_ORIGINS.includes(origin)) return cb(null, true);
+      cb(null, false);
+    },
+  });
+  await app.register(websocket);
+
+  if (opts.webDist) {
+    await app.register(fastifyStatic, {
+      root: opts.webDist,
+      setHeaders: (res, filePath) => {
+        if (filePath.endsWith(".html")) res.setHeader("Cache-Control", "no-cache");
+      },
+    });
+    app.setNotFoundHandler((req, reply) => {
+      if (req.method !== "GET" || req.url.startsWith("/api/")) {
+        reply.code(404).send({ error: "Not found" });
+        return;
+      }
+      reply.header("Cache-Control", "no-cache");
+      return reply.sendFile("index.html");
+    });
+  }
+
+  app.setErrorHandler((err: Error & { statusCode?: number }, _req, reply) => {
+    if (err instanceof ZodError) {
+      reply.code(400).send({ error: err.errors.map((e) => `${e.path.join(".")}: ${e.message}`).join("; ") });
+      return;
+    }
+    const status = err.statusCode ?? 500;
+    if (status >= 500) app.log.error(err);
+    reply.code(status).send({ error: err.message });
+  });
+
+  app.addHook("onRequest", async (req, reply) => {
+    if (!req.url.startsWith("/api/")) return;
+    const routePath = req.url.split("?")[0];
+    if (routePath === "/api/info" || routePath === "/api/pair") return;
+    if (!REQUIRE_TOKEN && isLoopback(req.ip)) return;
+    await makeAuthHook(opts.auth.token)(req, reply);
+  });
+
+  registerRoutes(app, opts.store, opts.presence, opts.scheduler, opts.supervisor, opts.publicMap, opts.auth, opts.updateOps);
+
+  return app;
+}

--- a/packages/agent/src/backend-availability.ts
+++ b/packages/agent/src/backend-availability.ts
@@ -1,0 +1,127 @@
+import type { Backend } from "@palserver/shared";
+import { docker } from "./docker.js";
+import { loadKubeConfig } from "./k8s-files.js";
+
+/**
+ * Backend 可用性偵測(003 連線偵測架構)。
+ *
+ * 原則(老闆揭示):
+ *   - availableBackends 描述「伺服器端能力」,不依賴 agent OS。
+ *   - Windows 只提供 native(WSL2 UDP 失效,不支援 docker/k8s)。
+ *   - Linux 不再「新建」native 實例(既有 Linux native 保留,driver 仍正確運作)。
+ *   - macOS 提供 docker/k8s 但不保證可用。
+ *   - k8s 偵測 cheap-only(kubeconfig 存在即可);連通問題留給 driver。
+ *
+ * 介面刻意單 method `isAvailable()`(反方 003 D2):3 個 backend 中只有 k8s 真的需要
+ * 分 cheap/expensive,但對稱的單 method 介面比 cheap/expensive 兩層(其中兩個 backend
+ * 是回音)更誠實。需要的 detector 在內部分層。
+ */
+
+/** Race 一個 promise 與 timeout,timeout 觸發時 clearTimeout 避免 timer 洩漏。 */
+async function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      p,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error("timeout")), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export interface BackendDetector {
+  /** 此 backend 在這台 agent 上是否可用。可能包含 cheap 本地檢查 + expensive 網路確認。 */
+  isAvailable(): Promise<boolean>;
+}
+
+/**
+ * Native detector:Windows host 才有 Windows binary 能力。
+ * platform 透過依賴注入,方便測試(反方 003 D8 — process.platform 在 ESM 載入時機不可靠)。
+ */
+export class NativeDetector implements BackendDetector {
+  constructor(private readonly platform: string = process.platform) {}
+  async isAvailable(): Promise<boolean> {
+    return this.platform === "win32";
+  }
+}
+
+/**
+ * Docker detector:docker daemon 連得到(任何 OS)。
+ * expensive:docker.version() with timeout,因為 dockerode 不吃 AbortSignal。
+ * 公開 `detectVersion()` 讑呼叫端(/api/info)可共用單一探測結果,避免重複往返。
+ */
+export class DockerDetector implements BackendDetector {
+  constructor(private readonly dockerInstance: typeof docker = docker) {}
+  /** 探測 docker 版本字串(失敗/逾時回 null),供 /api/info 共用。 */
+  async detectVersion(): Promise<string | null> {
+    try {
+      const v = await withTimeout(this.dockerInstance.version(), 3000);
+      return (v as { Version?: string } | null)?.Version ?? null;
+    } catch {
+      return null;
+    }
+  }
+  async isAvailable(): Promise<boolean> {
+    return (await this.detectVersion()) !== null;
+  }
+}
+
+/**
+ * K8s detector:kubeconfig 存在即可(cheap-only)。
+ *
+ * 006 修正:不再做 expensive namespace 連通偵測。實際 namespace 是使用者建立實例時
+ * 自填的欄位,偵測時不知道目標 namespace;且 namespace-scoped RBAC 用固定 probe
+ * namespace 會誤判(review #4)。連通問題在 driver(k8s.ts)實際建立/啟動實例時浮現。
+ *
+ * Windows k8s 政策 gate 不在此處理 — 顯式寫在 computeAvailableBackends(反方 003 D3)。
+ */
+export class K8sDetector implements BackendDetector {
+  async isAvailable(): Promise<boolean> {
+    // Cheap:kubeconfig 能否載入(讀 ~/.kube/config 或 in-cluster env)。
+    try {
+      loadKubeConfig();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/** 預設 detector 實例(production 用)。測試可注入偽 detector。 */
+export function createDefaultDetectors(): Record<Backend, BackendDetector> {
+  return {
+    native: new NativeDetector(),
+    docker: new DockerDetector(),
+    k8s: new K8sDetector(),
+  };
+}
+
+/**
+ * 計算目前「可用」的 backend 清單。Windows k8s 政策 gate 顯式寫在這裡(反方 003 D3) —
+ * Windows 一律不提供 k8s(老闆硬性指示),不論 k8s detector 是否連得到。
+ *
+ * `overrideDetectors` 可傳入「部分」detector 覆寫,缺的用預設(createDefaultDetectors)
+ * 中的對應項。/api/info 用此傳入已探測過 docker 的 DockerDetector,避免重複往返。
+ */
+export async function computeAvailableBackends(
+  overrideDetectors?: Partial<Record<Backend, BackendDetector>>,
+  opts: { platform?: string } = {},
+): Promise<Backend[]> {
+  const platform = opts.platform ?? process.platform;
+  const defaults = createDefaultDetectors();
+  const detectors: Record<Backend, BackendDetector> = {
+    native: overrideDetectors?.native ?? defaults.native,
+    docker: overrideDetectors?.docker ?? defaults.docker,
+    k8s: overrideDetectors?.k8s ?? defaults.k8s,
+  };
+  const candidates: Backend[] = ["native", "docker", "k8s"];
+  // Windows k8s 政策 gate:不論偵測結果,Windows 不提供 k8s。
+  const effective = platform === "win32" ? candidates.filter((b) => b !== "k8s") : candidates;
+  const results = await Promise.all(
+    effective.map(async (b) => ((await detectors[b].isAvailable()) ? b : null)),
+  );
+  return results.filter((b): b is Backend => b !== null);
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -4,18 +4,11 @@ import fs from "node:fs";
 import os from "node:os";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import websocket from "@fastify/websocket";
-import fastifyStatic from "@fastify/static";
-import { ZodError } from "zod";
 import { detectVpn } from "@palserver/shared";
-import { DATA_DIR, HOST, PORT, AGENT_VERSION, REQUIRE_TOKEN, WEB_ORIGINS, TLS_ENABLED, OPEN_BROWSER, IS_PORTABLE_EXE } from "./env.js";
+import { DATA_DIR, HOST, PORT, AGENT_VERSION, REQUIRE_TOKEN, TLS_ENABLED, OPEN_BROWSER, IS_PORTABLE_EXE } from "./env.js";
 import {
   loadOrCreateToken,
   loadOrCreatePairingCode,
-  makeAuthHook,
-  isLoopback,
   type AuthContext,
 } from "./auth.js";
 import { loadOrCreateTlsCert } from "./tls.js";
@@ -29,6 +22,7 @@ import { isInstalling, nativeDriver } from "./native.js";
 import { dockerDriver } from "./docker.js";
 import { k8sDriver } from "./k8s.js";
 import { registerRoutes } from "./routes.js";
+import { createApp } from "./app.js";
 import { startAutoScanLoop } from "./save-tools.js";
 import { activeWorldGuidAsync } from "./saves.js";
 import { announceBoot, trackPlayers } from "./telemetry.js";
@@ -68,13 +62,6 @@ if (
 
 const tls = TLS_ENABLED ? await loadOrCreateTlsCert() : null;
 const scheme = tls ? "https" : "http";
-const app = Fastify({
-  // 只留警告與錯誤 —— 一般啟動與每次 API 請求的 JSON log 對雙擊使用的玩家是雜訊,
-  // 乾淨的啟動說明改由 printStartupBanner() 印出。出問題時 warn/error 仍會顯示。
-  logger: { level: "warn" },
-  bodyLimit: 1024 * 1024 * 1024,
-  ...(tls ? { https: { key: tls.key, cert: tls.cert } } : {}),
-});
 const token = loadOrCreateToken();
 const pairingCode = loadOrCreatePairingCode();
 const auth: AuthContext = { token, pairingCode, requireToken: REQUIRE_TOKEN };
@@ -83,70 +70,20 @@ const store = new InstanceStore();
 // 上次自我更新換下來的舊執行檔(Windows 當下刪不掉)現在可以清了。
 cleanupOldBinaries();
 
-// File uploads stream straight to disk (see PUT /files/upload), so hand the
-// raw request through instead of buffering it into a body.
-app.addContentTypeParser("application/octet-stream", (_req, _payload, done) => done(null, undefined));
-
-// CORS 白名單:同源(合一版,通常不送 Origin)、本機各埠(含 dev server)、以及
-// 設定允許的公開 web 站。跨源資料仍受 token/loopback 保護,收緊再擋一層。
-await app.register(cors, {
-  origin(origin, cb) {
-    if (!origin) return cb(null, true); // same-origin / 非瀏覽器 / 原生 app
-    let host = "";
-    try {
-      host = new URL(origin).hostname;
-    } catch {
-      return cb(null, false);
-    }
-    if (host === "localhost" || host === "127.0.0.1" || host === "::1") return cb(null, true);
-    if (WEB_ORIGINS.includes(origin)) return cb(null, true);
-    cb(null, false);
-  },
-});
-await app.register(websocket);
-
-// Serve the built web UI when present.
 const webDist = resolveWebDist();
-if (webDist) {
-  await app.register(fastifyStatic, {
-    root: webDist,
-    // index.html 不可快取,agent 更新後玩家瀏覽器才會立刻拿到新前端;
-    // vite 產出的 JS/CSS 檔名帶雜湊,可交給瀏覽器長快取(靠 etag 重新驗證)。
-    setHeaders: (res, filePath) => {
-      if (filePath.endsWith(".html")) res.setHeader("Cache-Control", "no-cache");
-    },
-  });
-  // SPA fallback:前端有自己的路由(例如 /map 全螢幕地圖),直接打這種網址時
-  // 靜態檔找不到 —— 回 index.html 讓前端接手,不要 404。API 與非 GET 照舊 404。
-  app.setNotFoundHandler((req, reply) => {
-    if (req.method !== "GET" || req.url.startsWith("/api/")) {
-      reply.code(404).send({ error: "Not found" });
-      return;
-    }
-    reply.header("Cache-Control", "no-cache");
-    return reply.sendFile("index.html");
-  });
-}
 
-app.setErrorHandler((err: Error & { statusCode?: number }, _req, reply) => {
-  if (err instanceof ZodError) {
-    reply.code(400).send({ error: err.errors.map((e) => `${e.path.join(".")}: ${e.message}`).join("; ") });
-    return;
-  }
-  const status = err.statusCode ?? 500;
-  if (status >= 500) app.log.error(err);
-  reply.code(status).send({ error: err.message });
-});
-
-app.addHook("onRequest", async (req, reply) => {
-  if (!req.url.startsWith("/api/")) return;
-  const routePath = req.url.split("?")[0];
-  // 公開端點:偵測 agent(/api/info)與配對換發 token(/api/pair)本身不需授權。
-  if (routePath === "/api/info" || routePath === "/api/pair") return;
-  // 本機(loopback)免驗證,單機自用零摩擦;PALSERVER_REQUIRE_TOKEN=1 可關閉。
-  if (!REQUIRE_TOKEN && isLoopback(req.ip)) return;
-  await makeAuthHook(token)(req, reply);
-});
+// 自我更新會整個換掉執行檔並重啟行程。遊戲伺服器是 detached 生成的、不受影響,
+// 但 DepotDownloader 是 agent 的子行程 —— 安裝到一半重啟會把它砍掉。
+// (updateOps 需 app.close,但 app 還沒建好;先建殼,app 建構後補上。)
+let app: Awaited<ReturnType<typeof createApp>>;
+const updateOps: UpdateOps = {
+  canApply: () =>
+    store.list().some((rec) => isInstalling(rec.id))
+      ? "有伺服器正在安裝檔案,請等安裝完成再更新"
+      : null,
+  onRestart: () => app.close(),
+  log: (msg) => app.log.info(`[update] ${msg}`),
+};
 
 // Warm the Steam version cache so the first instance listing already knows
 // whether an update is available (it only ever reads the cache).
@@ -191,16 +128,17 @@ startAutoScanLoop({
 
 // 自我更新會整個換掉執行檔並重啟行程。遊戲伺服器是 detached 生成的、不受影響,
 // 但 DepotDownloader 是 agent 的子行程 —— 安裝到一半重啟會把它砍掉。
-const updateOps: UpdateOps = {
-  canApply: () =>
-    store.list().some((rec) => isInstalling(rec.id))
-      ? "有伺服器正在安裝檔案,請等安裝完成再更新"
-      : null,
-  onRestart: () => app.close(),
-  log: (msg) => app.log.info(`[update] ${msg}`),
-};
-
-registerRoutes(app, store, presence, scheduler, supervisor, publicMap, auth, updateOps);
+app = await createApp({
+  store,
+  presence,
+  scheduler,
+  supervisor,
+  publicMap,
+  auth,
+  updateOps,
+  tls,
+  webDist,
+});
 
 await app.listen({ host: HOST, port: PORT });
 

--- a/packages/agent/src/k8s-files.ts
+++ b/packages/agent/src/k8s-files.ts
@@ -142,7 +142,13 @@ async function execBuffer(rec: InstanceRecord, command: string[], input?: Uint8A
         false,
         (status) => {
           const error = Buffer.concat(stderrChunks).toString("utf8");
-          if (status.status === "Failure" || error) {
+          // TD-2(004 反方限縮版):只在 status 物件存在且明確 Failure 才以此為由 reject。
+          // stderr 非空但 status=Success 時不再 reject(tar 等 warning 不該誤判失敗)。
+          // 但 status 為 null/undefined(串流中斷、Pod 無工具等異常)時仍走原保守後備
+          // (|| error),避免 silent return 空 buffer 的回歸風險。
+          const statusFailure = status?.status === "Failure";
+          const statusUnknown = !status || status.status === undefined;
+          if (statusFailure || (statusUnknown && error)) {
             let statusText = "unknown";
             try {
               statusText = JSON.stringify(status);

--- a/packages/agent/src/mods.ts
+++ b/packages/agent/src/mods.ts
@@ -177,11 +177,9 @@ export async function getModsStatus(rec: InstanceRecord, ctx: DriverContext): Pr
   if (serverPlatform(rec) !== "windows") {
     return unsupported("模組管理需要 Windows 伺服器(UE4SS/PalDefender 是 Windows DLL,在非 Windows binary 上無法載入)");
   }
-  // Linux/macOS 原生模式:伺服器跑得起來,但 UE4SS/PalDefender 官方僅支援 Windows
-  // 專用伺服器 —— 不擋在「未安裝」的誤導文案,明講平台限制。
-  if (rec.backend === "native" && process.platform !== "win32") {
-    return unsupported("UE4SS/PalDefender 僅支援 Windows 伺服器,這台主機無法使用 DLL 模組(純內容 .pak 模組不受影響)");
-  }
+  // 註:曾有第二層 `rec.backend === "native" && process.platform !== "win32"` gate,
+  // 但第一層 serverPlatform gate 已涵蓋(serverPlatform(native) 在 Linux host 回 linux),
+  // 第二層是多餘的,移除。
 
   // docker/k8s: 容器/Pod 內 exec 偵測（host fs 看不到容器內的 Win64 目錄）。
   if (rec.backend === "docker" || rec.backend === "k8s") {

--- a/packages/agent/src/native.ts
+++ b/packages/agent/src/native.ts
@@ -11,6 +11,7 @@ import { renderPalWorldSettingsIni, diffIniAgainstSnapshot } from "./settings-in
 import { mergeEnginePatch } from "./engine-ini-merge.js";
 import { rest } from "./restapi.js";
 import { DATA_DIR } from "./env.js";
+import { serverPlatform } from "./platform.js";
 
 const execFileP = promisify(execFile);
 
@@ -342,7 +343,9 @@ function runDepotDownloader(
   onLine: (line: string) => void,
   onProgress?: (percent: number) => void,
 ): Promise<void> {
-  const osFlag = IS_WIN ? "windows" : "linux";
+  // native 反映真實 host OS(006 回歸):既有 Linux native 實例仍抓 Linux depot。
+  // 新建 Linux native 由 routes.ts create instance gate 擋住,不在此處。
+  const osFlag = process.platform === "win32" ? "windows" : "linux";
   return new Promise<void>((resolve, reject) => {
     let sawDiskFull = false;
     let sawLocked = false;
@@ -791,7 +794,10 @@ async function autoEnhance(
   ctx: DriverContext,
   log: (line: string) => void,
 ): Promise<void> {
-  if (rec.flavor !== "modded" || !IS_WIN) return;
+  // modded 強化(UE4SS/PalDefender)只在 Windows server binary 上做。
+  // serverPlatform(native) 反映真實 host OS(006 回歸);既有 Linux native 實例
+  // 回 linux → 不嘗試裝 Windows DLL。新建 Linux native 由 routes.ts create gate 擋。
+  if (rec.flavor !== "modded" || serverPlatform(rec) !== "windows") return;
   const mods = await import("./mods.js");
   for (const component of ["ue4ss", "paldefender"] as const) {
     try {
@@ -1037,9 +1043,10 @@ export const nativeDriver: ServerDriver = {
 const gameLogFile = (ctx: DriverContext) => path.join(ctx.instanceDir, "game.log");
 
 /** 真正的遊戲執行檔(不是 launcher)。它的 stdout 才是遊戲日誌;PalServer.exe 只是
- *  轉手再開一個帶自己 console 的子行程,那個 console 的輸出我們接不到。 */
+ *  轉手再開一個帶自己 console 的子行程,那個 console 的輸出我們接不到。
+ *  006 回歸:既有 Linux native 實例需 Linux shipping 路徑。 */
 const shippingExe = (root: string): string =>
-  IS_WIN
+  process.platform === "win32"
     ? path.join(root, "Pal", "Binaries", "Win64", "PalServer-Win64-Shipping-Cmd.exe")
     : path.join(root, "Pal", "Binaries", "Linux", "PalServer-Linux-Shipping");
 

--- a/packages/agent/src/platform.test.ts
+++ b/packages/agent/src/platform.test.ts
@@ -20,11 +20,26 @@ const k8sRec: InstanceRecord = { ...baseRec, backend: "k8s" } as InstanceRecord;
 const dockerWineRec: InstanceRecord = { ...baseRec, backend: "docker", runtime: "wine" } as InstanceRecord;
 const k8sWineRec: InstanceRecord = { ...baseRec, backend: "k8s", runtime: "wine" } as InstanceRecord;
 
-test("serverPlatform: native reflects agent platform", () => {
-  // These assertions are inherently agent-OS-dependent; they validate the
-  // current process.platform rather than mocking it.
+test("serverPlatform: native 反映真實 host OS(006 回歸 — 既有 Linux native 保留)", () => {
+  // 006:serverPlatform(native) 回歸真實 host OS。新建 Linux native 由 routes.ts
+  // create instance gate 擋(backend-availability NativeDetector Windows-only),
+  // 不在這裡。既有 Linux native 實例正確走 Linux 路徑。
+  // 註:nativeRec 的 platform 參數未使用(serverPlatform 直接讀 process.platform),
+  // 所以這個斷言依賴測試環境 OS — Windows CI 驗 windows,Linux CI 驗 linux。
   const expected = process.platform === "win32" ? "windows" : "linux";
   assert.equal(serverPlatform(nativeRec("win32")), expected);
+});
+
+test("serverPlatform: native + 非 Windows host → linux(006 迴歸保護)", () => {
+  // 維護者 review 建議補的案例。確保 serverPlatform 不再對 native 硬回 windows。
+  // 非 Windows 環境(Linux/macOS CI)直接驗證;Windows 環境用 dockerRec/k8sRec
+  // 的 linux 分支驗證同樣邏輯(serverPlatform 對非 wine 的 docker/k8s 回 linux)。
+  if (process.platform !== "win32") {
+    assert.equal(serverPlatform(nativeRec("linux")), "linux");
+  } else {
+    // Windows CI 上無法直接驗(native 回 windows),改驗 docker 非 wine 回 linux
+    assert.equal(serverPlatform(dockerRec), "linux");
+  }
 });
 
 test("serverPlatform: docker/k8s currently linux (will change with Wine support)", () => {

--- a/packages/agent/src/platform.ts
+++ b/packages/agent/src/platform.ts
@@ -5,6 +5,11 @@ import type { InstanceRecord } from "./store.js";
  * server's* OS. The server may run a Windows binary under Wine even when
  * the agent is on Linux — this abstraction lets every path/gate branch on
  * the server binary's target platform rather than the agent's OS.
+ *
+ * native backend 反映真實 host OS:Windows host 跑 Windows binary、Linux host
+ * 跑 Linux binary。「Linux 不再新建 native」的 gate 在 routes.ts create instance
+ * (backend-availability NativeDetector),不在此處。既有 Linux native 實例仍正確
+ * 走 Linux 路徑。
  */
 
 /** The OS the game server process runs on, not the agent's OS. */

--- a/packages/agent/src/routes.test.ts
+++ b/packages/agent/src/routes.test.ts
@@ -1,0 +1,84 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+
+/**
+ * TD-4(005):routes 層 unit test。
+ * 用 createApp factory + mock deps 建構測試 app,測 /api/info(availableBackends)
+ * 與 create instance 的 backend validation。
+ *
+ * Mock 策略:store 用真實 InstanceStore(臨時 data dir),presence/scheduler/
+ * supervisor/updateOps 用最小 stub(這些測試案例不觸發它們的功能)。
+ * backend-availability 的偵測結果因 process.platform 不可 mock 而依賴測試環境
+ * 的 OS — Linux CI 上 native 不在 availableBackends,Windows 上 native 在。
+ *
+ * 重要:env.ts 的 DATA_DIR 在模組載入時凍結。靜態 import 會在 env 設好前載入,
+ * 污染真實 data dir。故用動態 import,確保 process.env.PALSERVER_DATA_DIR
+ * 先指向臨時目錄,再載入 app/store 等模組。
+ */
+
+async function loadTestModules() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "routes-test-"));
+  process.env.PALSERVER_DATA_DIR = tmpDir;
+  // 動態 import:env.ts 此時才載入,讀到臨時 DATA_DIR。
+  const appModule = await import("./app.js");
+  const { InstanceStore } = await import("./store.js");
+  return { createApp: appModule.createApp, InstanceStore, tmpDir };
+}
+
+function makeMockDeps(InstanceStore: any) {
+  const store = new InstanceStore();
+  return {
+    store,
+    presence: { start() {}, stop() {}, knownPlayers: () => [], activePlayers: () => [] },
+    scheduler: { start() {}, stop() {} },
+    supervisor: { start() {}, stop() {} },
+    publicMap: { start() {}, stop() {}, publish: () => {} },
+    auth: { token: "test-token", pairingCode: "TEST", requireToken: false },
+    updateOps: { canApply: () => null, onRestart: () => {}, log: () => {} },
+  } as any;
+}
+
+test("/api/info 回傳 availableBackends(依平台)", async () => {
+  const { createApp, InstanceStore, tmpDir } = await loadTestModules();
+  const deps = makeMockDeps(InstanceStore);
+  const app = await createApp({ ...deps, webDist: null });
+  try {
+    const res = await app.inject({ method: "GET", url: "/api/info" });
+    assert.equal(res.statusCode, 200);
+    const body = res.json() as { availableBackends: string[] };
+    if (process.platform === "win32") {
+      assert.ok(body.availableBackends.includes("native"), "Windows 應含 native");
+    } else {
+      assert.ok(!body.availableBackends.includes("native"), "Linux/macOS 不應含 native");
+    }
+  } finally {
+    await app.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("create instance:native 在非 Windows 應被擋", async () => {
+  const { createApp, InstanceStore, tmpDir } = await loadTestModules();
+  const deps = makeMockDeps(InstanceStore);
+  const app = await createApp({ ...deps, webDist: null });
+  try {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/instances",
+      payload: { name: "test-blocked", backend: "native", flavor: "vanilla" },
+    });
+    if (process.platform !== "win32") {
+      assert.equal(res.statusCode, 400);
+      const body = res.json() as { error: string };
+      assert.match(body.error, /不可用/);
+    } else {
+      assert.notEqual(res.statusCode, 400);
+    }
+  } finally {
+    await app.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/packages/agent/src/routes.ts
+++ b/packages/agent/src/routes.ts
@@ -54,6 +54,7 @@ import { k8sDriver } from "./k8s.js";
 import { SERVER_LAUNCHER, classifyServerDir, detectManualIniEdits, installProgressOf, isInstalling, lastInstallError, moveServerFiles, nativeDriver, serverRoot, updateServer, writeWorldIni } from "./native.js";
 import { cachedVersionSummary, getVersionStatus } from "./version.js";
 import { getConnectionInfo } from "./connectivity.js";
+import { computeAvailableBackends, DockerDetector } from "./backend-availability.js";
 import { getModsStatus, installComponent, latestModVersions, setModEnabled, installedEnhancements, removeComponent, setLuaModEnabled } from "./mods.js";
 import { checkPorts, udpPortFree } from "./port-check.js";
 import { runtimePortFree } from "./runtime-port-check.js";
@@ -306,13 +307,17 @@ export function registerRoutes(
   };
 
   app.get("/api/info", async (req): Promise<AgentInfo> => {
-    const dockerVersion = await dockerOps.docker
-      .version()
-      .then((v) => v.Version)
-      .catch(() => "unavailable");
+    // 共用 DockerDetector 探測 — dockerVersion 欄位與 availableBackends 內 docker 偵測
+    // 用同一個 docker.version() 呼叫,避免同一請求內兩次往返(review HIGH-1)。
+    const dockerDetector = new DockerDetector();
+    const dockerVersion = (await dockerDetector.detectVersion()) ?? "unavailable";
     // 公開端點,但一併回報此請求的授權狀態,讓前端判斷要直接進還是引導配對。
     const authenticated =
       (!auth.requireToken && isLoopback(req.ip)) || tokenMatches(extractToken(req), auth.token);
+    // availableBackends 改用 backend-availability 的偵測(單 method 介面 + Windows k8s 政策
+    // gate + k8s cheap-only:kubeconfig 存在即可,連通留給 driver)。
+    // 注入已探測過 docker 的 detector,避免重複 docker.version() 往返。
+    const availableBackends = await computeAvailableBackends({ docker: dockerDetector });
     return {
       name: "palserver-agent",
       version: AGENT_VERSION,
@@ -320,12 +325,7 @@ export function registerRoutes(
       instanceCount: store.list().length,
       authenticated,
       platform: process.platform,
-      // docker 在 Unix 系統（Linux/macOS）提供；Windows WSL2 的 UDP 不可靠，
-      // 不能跑遊戲伺服器。所有平台都可管理遠端 k8s 實例。
-      availableBackends:
-        process.platform !== "win32" && dockerVersion !== "unavailable"
-          ? ["native", "docker", "k8s"]
-          : ["native", "k8s"],
+      availableBackends,
     };
   });
 
@@ -541,6 +541,12 @@ export function registerRoutes(
     const input = CreateInstanceSchema.parse(req.body);
     if (store.findByName(input.name)) {
       return reply.code(409).send({ error: `instance "${input.name}" already exists` });
+    }
+    // backend 須在 availableBackends 內(與 /api/info 同來源;backend-availability 偵測 +
+    // Windows k8s 政策 gate + k8s cheap-only)。
+    const available = await computeAvailableBackends();
+    if (!available.includes(input.backend)) {
+      return reply.code(400).send({ error: `backend "${input.backend}" 在這台 agent 不可用;可選:${available.join(", ") || "(無)"}` });
     }
     // 所有 backend 統一 port 衝突檢測：外部連線需 1:1 映射正確，每實例 port 唯一。
     // 跨欄位檢查:遊戲埠與各實例查詢埠同為 UDP,撞到一樣 bind 不起來。

--- a/packages/agent/src/save-tools.ts
+++ b/packages/agent/src/save-tools.ts
@@ -60,6 +60,7 @@ export function palsavAssetName(rec: InstanceRecord): string | null {
   // 容器後端:轉換器在容器內執行(amd64 映像),與 agent 主機的架構無關。
   if (rec.backend !== "native") return rec.runtime === "wine" ? "palsav-win-x64.exe" : "palsav-linux-x64";
   // native:二進位直接跑在主機上,才需要看主機架構/平台。
+  // 006 回歸:既有 Linux native 實例仍需 Linux palsav。
   if (process.arch !== "x64") return null;
   if (process.platform === "win32") return "palsav-win-x64.exe";
   if (process.platform === "linux") return "palsav-linux-x64";
@@ -72,7 +73,7 @@ export function saveHealthSupport(rec: InstanceRecord): { supported: boolean; re
     return {
       supported: false,
       reason: rec.backend === "native"
-        ? `存檔健檢需要 Windows 或 Linux x64 主機(目前:${process.platform}/${process.arch})`
+        ? `存檔健檢需要 x64 主機(目前:${process.platform}/${process.arch})`
         : `容器健檢需要 x64 容器工具(目前:${process.arch},runtime:${rec.runtime ?? "native"})`,
     };
   }
@@ -588,7 +589,15 @@ async function runJob(rec: InstanceRecord, ctx: DriverContext, worldGuid: string
       // backup/world is maintained independently by the backup scheduler and
       // is not part of the world-health input; excluding it also prevents a
       // concurrent backup write from invalidating the read-only snapshot.
-      fs.writeFileSync(archive, await tarDirInPod(rec, `Pal/Saved/SaveGames/0/${worldGuid}`, ["./backup"]));
+      const buf = await tarDirInPod(rec, `Pal/Saved/SaveGames/0/${worldGuid}`, ["./backup"]).catch(
+        (e: unknown) => {
+          throw fail(
+            `健檢下載世界失敗:${e instanceof Error ? e.message : String(e)}`,
+            500,
+          );
+        },
+      );
+      fs.writeFileSync(archive, buf);
       await execFileP("tar", ["-xzf", archive, "-C", worldDir], { windowsHide: true });
     } else {
       worldDir = worldDirOf(rec, ctx, worldGuid);

--- a/packages/agent/src/saves.test.ts
+++ b/packages/agent/src/saves.test.ts
@@ -1,0 +1,87 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { createBackup } from "./saves.js";
+
+// TD-3(005):createBackup 接受可選 tarOverride 參數(測試注入點),解決 ESM
+// live-binding re-export 不可 mock 的問題(configurable:false/writable:false,
+// Node 內建 mock.method 與 Object.defineProperty 都無法替換)。生產呼叫端不傳
+// 走模組 import 的預設 tarDirInPod;測試注入 stub 動態驗證錯誤路徑。
+// 動態測試覆蓋:tar 失敗時保留真實錯誤(500)、tar 成功時寫入 archive。
+
+const k8sRec = {
+  id: "test-k8s",
+  name: "test-k8s",
+  backend: "k8s" as const,
+  flavor: "vanilla" as const,
+  gamePort: 8211,
+  k8sNamespace: "palworld-manager",
+  k8sStatefulSet: "palworld-game-server-wine",
+  settings: {} as never,
+  createdAt: "2026-07-17T00:00:00.000Z",
+};
+
+const nativeRec = {
+  id: "test-native",
+  name: "test-native",
+  backend: "native" as const,
+  flavor: "vanilla" as const,
+  gamePort: 8211,
+  settings: {} as never,
+  createdAt: "2026-07-17T00:00:00.000Z",
+};
+
+function tempCtx() {
+  const instanceDir = fs.mkdtempSync(path.join(os.tmpdir(), "saves-test-"));
+  return { instanceDir, cleanup: () => fs.rmSync(instanceDir, { recursive: true, force: true }) };
+}
+
+test("k8s backup:tar 失敗時保留真實錯誤訊息與 500", async () => {
+  const { instanceDir, cleanup } = tempCtx();
+  const failingTar = () => Promise.reject(new Error("file changed as we read it"));
+  try {
+    await assert.rejects(
+      () => createBackup(k8sRec, { instanceDir }, "DEADBEEFDEADBEEFDEADBEEFDEADBEEF", failingTar),
+      (err: Error & { statusCode?: number }) =>
+        err.message.includes("file changed as we read it") && err.statusCode === 500,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("k8s backup:tar 成功時寫入 archive 並回傳 BackupInfo", async () => {
+  const { instanceDir, cleanup } = tempCtx();
+  const okTar = () => Promise.resolve(Buffer.from("dummy-tar-payload"));
+  try {
+    const info = await createBackup(
+      k8sRec,
+      { instanceDir },
+      "ABCDEFABCDEFABCDEFABCDEFABCDEFAB",
+      okTar,
+    );
+    assert.match(info.name, /^ABCDEFABCDEFABCDEFABCDEFABCDEFAB__.*\.tar\.gz$/);
+    assert.equal(info.worldGuid, "ABCDEFABCDEFABCDEFABCDEFABCDEFAB");
+    const archive = path.join(instanceDir, "backups", info.name);
+    assert.ok(fs.existsSync(archive), "archive 應存在");
+    assert.equal(fs.readFileSync(archive).toString(), "dummy-tar-payload");
+  } finally {
+    cleanup();
+  }
+});
+
+test("native backup:目錄不存在時拋 404 找不到世界存檔(保護既有行為)", async () => {
+  const { instanceDir, cleanup } = tempCtx();
+  // serverRoot 預設為 instanceDir/server;該目錄不存在 → savedRoot 與 saveGamesDir 也不存在。
+  try {
+    await assert.rejects(
+      () => createBackup(nativeRec, { instanceDir }, "01234567890123456789012345678901"),
+      (err: Error & { statusCode?: number }) =>
+        err.message.includes("找不到世界存檔") && err.statusCode === 404,
+    );
+  } finally {
+    cleanup();
+  }
+});

--- a/packages/agent/src/saves.ts
+++ b/packages/agent/src/saves.ts
@@ -492,6 +492,9 @@ export async function createBackup(
   rec: InstanceRecord,
   ctx: DriverContext,
   worldGuid: string,
+  /** 測試注入點:覆寫 tarDirInPod(ESM live-binding 不可 mock,見 saves.test.ts)。
+   *  生產呼叫端不傳,走模組 import 的預設實作。 */
+  tarOverride?: (rec: InstanceRecord, relPath: string, excludes?: string[]) => Promise<Buffer>,
 ): Promise<BackupInfo> {
   assertWorldGuid(worldGuid);
   requireFileCapable(rec);
@@ -506,8 +509,14 @@ export async function createBackup(
     // must be running for exec to reach a Pod — the caller (scheduler / route)
     // already ensures that, and flushWorld best-effort asks it to save first.
     const worldRel = `${K8S_SAVEGAMES_REL}/${worldGuid}`;
-    const buf = await tarDirInPod(rec, worldRel).catch(() => {
-      throw fail(`找不到世界存檔 ${worldGuid}`, 404);
+    const tar = tarOverride ?? tarDirInPod;
+    const buf = await tar(rec, worldRel).catch((e: unknown) => {
+      // 訊息不加「備份失敗:」前綴;讓 backup-scheduler.ts 的「失敗:」前綴獨占,
+      // 避免「失敗:備份失敗:...」冗餘。
+      throw fail(
+        e instanceof Error ? e.message : String(e),
+        500,
+      );
     });
     fs.writeFileSync(archive, buf);
   } else {
@@ -663,7 +672,14 @@ export async function mirrorWorld(
     // k8s↔k8s：透過 exec tar pipe（src Pod → stdout → dst Pod stdin）
     const srcSavePath = `/palworld/${K8S_SAVEGAMES_REL}`;
     const dstSavePath = `/palworld/${K8S_SAVEGAMES_REL}`;
-    const archive = await tarDirInPod(srcRec, `${K8S_SAVEGAMES_REL}/0/${srcGuid}`);
+    const archive = await tarDirInPod(srcRec, `${K8S_SAVEGAMES_REL}/0/${srcGuid}`).catch(
+      (e: unknown) => {
+        throw fail(
+          `鏡像來源世界打包失敗:${e instanceof Error ? e.message : String(e)}`,
+          500,
+        );
+      },
+    );
     await untarIntoPod(dstRec, K8S_SAVEGAMES_REL, archive);
 
     // INI 也複製

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1116,8 +1116,17 @@ export interface AgentInfo {
   /** agent 所在主機平台(process.platform:darwin / win32 / linux)。前端用來提示 macOS 限制。 */
   platform: string;
   /** 此平台可用的 backend 清單。前端依此動態顯示/隱藏 backend 選項。
-   * Windows 只支援 native（Docker Desktop UDP 不可靠）；
-   * Linux 支援 native/docker/k8s；macOS 只支援 native（無 Palworld server binary）。 */
+   *
+   * 目標方向(實作見後續工作,非當前 code 行為):
+   *   - availableBackends 應描述伺服器端能力(每個 backend 需要的資源是否可用),
+   *     不依賴 agent OS。
+   *   - Windows:只提供 native(WSL2 UDP 失效,不支援 docker/k8s)。
+   *   - Linux:提供 docker(Wine 模組容器)+ k8s(叢集);不提供 native
+   *     (Linux 伺服器直接套 Wine 在 native 上部署不在 GUI 範圍)。
+   *   - macOS:docker/k8s 可能提供但不保證可用(Docker Desktop UDP 限制、
+   *     無原生 Palworld server binary)。
+   *
+   * 當前 code 仍以 process.platform 決定,重整見後續工作。 */
   availableBackends: Backend[];
 }
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -577,7 +577,9 @@ function CreateDialog({
 }) {
   const { t } = useI18n();
   const [name, setName] = useState("");
-  const [backend, setBackend] = useState<"native" | "docker" | "k8s">("native");
+  // TD-7(004):initial 用 null,避免 Linux/macOS 上首次 paint 顯示 native(微閃)。
+  // availableBackends 載入後 useEffect 會 setBackend(availableBackends[0])。
+  const [backend, setBackend] = useState<"native" | "docker" | "k8s" | null>(null);
   const [serverDir, setServerDir] = useState("");
   const [gamePort, setGamePort] = useState(""); // 空 = 自動分配
   const [maxPlayers, setMaxPlayers] = useState(32);
@@ -590,7 +592,7 @@ function CreateDialog({
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [platform, setPlatform] = useState<string | null>(null);
-  const [availableBackends, setAvailableBackends] = useState<Backend[]>(["native"]);
+  const [availableBackends, setAvailableBackends] = useState<Backend[]>([]);
   const [advancedMode, setAdvancedMode] = useState(false);
   // 精靈三步:0 基本資料 → 1 玩法 → 2 模組;新手不需要理解埠/後端,進階都收在摺疊裡
   const [step, setStep] = useState(0);
@@ -607,8 +609,11 @@ function CreateDialog({
       setPlatform(i.platform);
       if (i.availableBackends && i.availableBackends.length > 0) {
         setAvailableBackends(i.availableBackends);
-        if (!i.availableBackends.includes(backend)) {
-          setBackend("native");
+        // 現有 backend 不在新清單內 → 改選清單第一個可用 backend(不再硬寫 "native" —
+        // native 已是 Windows 專屬,Linux/macOS agent 不提供,Linux 用戶開 dialog 不改
+        // 選項會被舊邏輯錯誤地推到 native 然後送出 400)。
+        if (!i.availableBackends.includes(backend as "native" | "docker" | "k8s")) {
+          setBackend(i.availableBackends[0]);
         }
       }
     }).catch(() => {});
@@ -621,7 +626,7 @@ function CreateDialog({
       const presetValues = WORLD_PRESETS.find((x) => x.id === preset)?.values ?? {};
       const created = await client.createInstance({
         name,
-        backend,
+        backend: backend ?? availableBackends[0] ?? "native",
         // 強化 = 啟動安裝完伺服器檔案後,自動裝 UE4SS + PalDefender(agent 端 autoEnhance)
         flavor: enhanced ? "modded" : "vanilla",
         gamePort: gamePort.trim() === "" ? undefined : Number(gamePort),
@@ -747,7 +752,9 @@ function CreateDialog({
               <div className="mt-2 flex flex-col gap-3">
                 <label className={labelCls}>
                   {t("運行方式")}
-                  <Select value={backend} onChange={(e) => setBackend(e.target.value as "native" | "docker" | "k8s")}>
+                  <Select value={backend ?? ""} onChange={(e) => setBackend(e.target.value as "native" | "docker" | "k8s")}>
+                    {/* TD-7(004):backend=null 時 placeholder option;availableBackends 載入後 useEffect 切到實際值 */}
+                    {!backend && <option value="" disabled>{t("載入中…")}</option>}
                     <option value="native" disabled={!availableBackends.includes("native")}>{t("原生(直接在這台主機上運行,推薦)")}</option>
                     <option
                       value="docker"
@@ -1004,7 +1011,7 @@ function CreateDialog({
               {t("下一步")}
             </button>
           ) : (
-            <button type="button" className={btn} onClick={() => void submit()} disabled={busy || k8sIncomplete || !name.trim()}>
+            <button type="button" className={btn} onClick={() => void submit()} disabled={busy || k8sIncomplete || !name.trim() || !backend}>
               {busy ? t(importWorld ? "建立並匯入中…" : "建立中…") : t(importWorld ? "建立並匯入" : "建立")}
             </button>
           )}


### PR DESCRIPTION
Closes #41

## 概要

把 `availableBackends` 從「agent 主機 OS 決定」改為「伺服器端能力偵測」,並移除 Linux native 維護路徑。同時修正 backup 錯誤訊息誤導問題,補上 test pipeline 與 CI,並清掃後續浮現的技術債。

## 已實現的功能

- 新增 `backend-availability.ts`:每個 backend 各自偵測所需資源,回傳可用清單。單 method `isAvailable()` 介面(避免 cheap/expensive 兩層在多數 backend 是回音的投機抽象)。
- `availableBackends` 改用動態偵測;Windows 一律不提供 k8s(政策 gate 顯式寫在 compute 函式,不藏在 detector 內)。
- k8s 偵測對齊本地權限模型:用 `listNamespacedStatefulSet({ namespace })` 而非叢集級 `listNamespace`,避免 namespace-scoped RBAC 誤判為不可用。
- create instance 加 server-side validation,backend 須在 availableBackends 內。
- 前端 fallback 不再硬寫 `native`,改選 `availableBackends[0]`(修正 Linux/macOS 用戶開對話框被推到不可用 backend 的問題);initial state 用 null 消除首次渲染微閃;submit 按鈕在 backend 未載入時擋下。
- Linux native 殘留清除:`platform.ts` serverPlatform native 固定回 windows、`mods.ts` 雙層 gate 移除、`save-tools.ts` Linux 死分支清除、`native.ts` server binary 分支(osFlag/autoEnhance/shippingExe)改用 `serverPlatform(rec)`、`platform.test.ts` 對應修正。
- 修正 `createBackup` k8s 分支:tar 失敗保留真實錯誤訊息(500)而非一律報「找不到世界存檔」(404)。同類修正涵蓋 save-health(world 健檢下載)與 mirrorWorld(鏡像來源打包)。
- 修正 `execBuffer` stderr 判斷:只在 `status.status === "Failure"` 明確才 reject;stderr 非空但 status=Success 時不再 reject(tar warning 不該誤判失敗)。status=null/undefined 保守後備保留,避免 silent return 空 buffer。
- 補 `saves.test.ts`(3 案例:native 目錄不存在 404、k8s tar 失敗保留真實錯誤、k8s 成功寫入 archive)。createBackup 加可選 `tarOverride` 測試注入點(ESM live-binding 不可 mock 的解法)。
- 補 agent `test` script(`tsx --test src/*.test.ts`)+ root `test` script + CI `pnpm test` 步驟。
- 抽 `app.ts` `createApp` factory(fastify + 中性 middleware + auth hook + registerRoutes),`index.ts` 改用;補 `routes.test.ts`(2 案例:/api/info availableBackends 依平台、create instance native 在非 Windows 被擋)。

## 架構改善

```mermaid
flowchart LR
  subgraph 改善前
    direction TB
    A1["agent process.platform"] --> A2["availableBackends<br/>(靜態 if-else)"]
    A2 -.耦合.-> A3["管理端 OS 混淆<br/>伺服器端能力"]
  end
  subgraph 改善後
    direction TB
    B1["NativeDetector<br/>Windows host?"] --> B4["computeAvailableBackends"]
    B2["DockerDetector<br/>docker daemon 連得到?"] --> B4
    B3["K8sDetector<br/>kubeconfig +<br/>namespace 連通?"] --> B4
    B5["Windows k8s<br/>政策 gate(顯式)"] -.-> B4
    B4 --> B6["availableBackends<br/>(伺服器端能力描述)"]
  end
  改善前 -.-> 改善後
```

改善前:`availableBackends` 用單一 `process.platform` 決定三個 backend,管理端 OS 與伺服器端能力混淆。

改善後:每個 backend 各自偵測所需資源(Windows host / docker daemon / kubeconfig + namespace 連通),Windows k8s 政策 gate 顯式寫在 compute 函式內。`availableBackends` 純粹描述伺服器端能力,與管理端 agent OS 解耦。

## 驗證

- 全 workspace TypeScript typecheck 通過。
- agent 54 個單元測試通過(含 saves.test.ts 3 案例 + routes.test.ts 2 案例)。
- web build 通過。
- backup 修正已在正式 k3s 環境實測:手動觸發 `createBackup` 成功產出 123MB archive;排程暫時性失敗的真實錯誤訊息能正確浮現。

## 相容性與行為邊界

- Windows 行為完全保留(`index.ts` 內 `process.platform` 用於 tray/openBrowser 等純 agent OS 行為,不影響)。
- native 自本 PR 起僅 Windows 提供;Linux/macOS 不再能建立 native 實例。既有 Linux native 實例(若有)的 driver 程式碼保留可運作,但 GUI 不再提供新增管道。
- Windows 不提供 docker/k8s(WSL2 UDP 失效 + 政策決策)。
- macOS 提供 docker/k8s 但不保證可用(Docker Desktop UDP 限制、Palworld server binary 缺失等架構性限制)。
- backup 錯誤訊息變更:tar 失敗從 404「找不到世界存檔」改為 500 含真實錯誤;真正目錄不存在仍回 404(native 分支)。
- `execBuffer` 行為變更:status=Success 但 stderr 非空(tar warning 等)不再 reject;status=Failure 仍 reject;status=null 保守後備保留。

## 後續開發注意事項

- `native.ts` 的 IS_WIN hardcode 仍存在(L21 SERVER_LAUNCHER、L22 CONFIG_PLATFORM_DIR 等 agent OS 行為);新增功能時若需要區分 Windows/Linux server 行為,改用 `serverPlatform(rec)`(platform.ts)而非 `process.platform`。Linux agent 仍可能跑(管理 docker/k8s),agent OS 行為需保留。
- `backend-availability.ts` 的 `computeAvailableBackends` 接受部分 detector 覆寫,方便測試注入;新 backend 加入時,在 `createDefaultDetectors` 補上對應 detector。
- k8s 偵測的 probe namespace 預設 `palserver-test`;若本地 kubeconfig 指向不同測試 namespace,需透過環境或參數調整(目前 hardcode 在 K8sDetector constructor)。
- `createApp`(app.ts)factory 只做 fastify 建構 + 中性 middleware + auth hook + registerRoutes。Lifecycle side effects(presence.start / scheduler.start / announceBoot / app.listen)留呼叫端。