### PR TITLE
feat: 支援 Linux ARM64 主機(FEX 轉譯)

### DIFF
--- a/images/vanilla-arm64/Dockerfile
+++ b/images/vanilla-arm64/Dockerfile
@@ -1,0 +1,46 @@
+# palserver/vanilla-arm64 — native Linux Palworld dedicated server on ARM64 hosts.
+# 官方只出 x86-64 伺服器執行檔,ARM64 主機(樹莓派/NanoPi/Ampere…)要靠
+# FEX(x86-64→ARM64 動態轉譯器)執行;作法參考 nitrog0d/palworld-arm64。
+# DepotDownloader 抓原生 arm64 版 —— 下載/驗證不吃轉譯,只有遊戲本體經 FEX 跑。
+# 與 images/vanilla 同一套容器介面(/data/saved、/data/config、CMD 啟動參數),
+# agent 的 docker 後端無需任何改動,建好後在建立實例時指定本鏡像即可。
+FROM ubuntu:24.04
+
+ARG DEPOTDOWNLOADER_VERSION=3.4.0
+# FEX 依 CPU 世代出多種最佳化包:RK3588(Cortex-A76)/Ampere 皆 >= ARMv8.2;
+# 更老的板子(樹莓派 4 之類 ARMv8.0)建置時帶 --build-arg FEX_VARIANT=armv8.0。
+ARG FEX_VARIANT=armv8.2
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      ca-certificates curl unzip xdg-user-dirs software-properties-common expect \
+    && add-apt-repository -y ppa:fex-emu/fex \
+    && apt-get install -y --no-install-recommends "fex-emu-${FEX_VARIANT}" \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL -o /tmp/dd.zip \
+      "https://github.com/SteamRE/DepotDownloader/releases/download/DepotDownloader_${DEPOTDOWNLOADER_VERSION}/DepotDownloader-linux-arm64.zip" \
+    && unzip /tmp/dd.zip -d /opt/depotdownloader \
+    && chmod +x /opt/depotdownloader/DepotDownloader \
+    && ln -s /opt/depotdownloader/DepotDownloader /usr/local/bin/DepotDownloader \
+    && rm /tmp/dd.zip
+
+# Base image ships an "ubuntu" user at UID 1000; rename it instead of
+# fighting over the UID (kept at 1000 so Linux-host bind mounts map cleanly).
+RUN usermod -l palworld -d /home/palworld -m ubuntu && groupmod -n palworld ubuntu
+USER palworld
+ENV HOME=/home/palworld USER=palworld
+WORKDIR /home/palworld
+
+# FEX 需要一份 x86-64 rootfs 當 guest 系統函式庫,建置期先抓好。
+# -x 解成目錄而非掛 squashfs —— 容器內沒有 FUSE 可用;
+# unbuffer 是因為 fetcher 的 isatty 判斷在無 tty 的 docker build 會出錯。
+RUN unbuffer FEXRootFSFetcher -y -x
+
+COPY --chmod=755 entrypoint.sh /entrypoint.sh
+
+# /data/saved  -> Pal/Saved (world saves, agent bind-mounts this)
+# /data/config -> agent-rendered PalWorldSettings.ini (read-only)
+VOLUME ["/data/saved"]
+
+EXPOSE 8211/udp 8212/tcp
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/images/vanilla-arm64/entrypoint.sh
+++ b/images/vanilla-arm64/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ID=2394010          # Palworld Dedicated Server
+SDK_APP_ID=1007         # Steamworks SDK Redist (provides steamclient.so)
+INSTALL_DIR="$HOME/palworld"
+SAVED_DIR="/data/saved"
+CONFIG_SRC="/data/config/PalWorldSettings.ini"
+CONFIG_DST="$INSTALL_DIR/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"
+
+# The server dlopens ~/.steam/sdk64/steamclient.so at runtime; fetch it once
+# from the Steamworks SDK redist depot.
+if [ ! -f "$HOME/.steam/sdk64/steamclient.so" ]; then
+  echo "[palserver] fetching steamclient.so (app $SDK_APP_ID)..."
+  DepotDownloader -app "$SDK_APP_ID" -dir "$HOME/sdk" -os linux -osarch 64
+  mkdir -p "$HOME/.steam/sdk64"
+  cp "$HOME/sdk/linux64/steamclient.so" "$HOME/.steam/sdk64/steamclient.so"
+fi
+
+echo "[palserver] installing/updating Palworld dedicated server (app $APP_ID)..."
+DepotDownloader -app "$APP_ID" -dir "$INSTALL_DIR" -os linux -osarch 64 -validate
+
+# Persist Pal/Saved (worlds, players, generated config) on the mounted volume.
+mkdir -p "$SAVED_DIR"
+if [ -d "$INSTALL_DIR/Pal/Saved" ] && [ ! -L "$INSTALL_DIR/Pal/Saved" ]; then
+  cp -rn "$INSTALL_DIR/Pal/Saved/." "$SAVED_DIR/" || true
+  rm -rf "$INSTALL_DIR/Pal/Saved"
+fi
+mkdir -p "$INSTALL_DIR/Pal"
+ln -sfn "$SAVED_DIR" "$INSTALL_DIR/Pal/Saved"
+
+# Apply the agent-rendered settings, if provided.
+if [ -f "$CONFIG_SRC" ]; then
+  mkdir -p "$(dirname "$CONFIG_DST")"
+  cp "$CONFIG_SRC" "$CONFIG_DST"
+  echo "[palserver] applied PalWorldSettings.ini from agent"
+fi
+
+echo "[palserver] starting PalServer (via FEX x86-64 emulation)..."
+chmod +x "$INSTALL_DIR/PalServer.sh" "$INSTALL_DIR"/Pal/Binaries/Linux/* 2>/dev/null || true
+# FEXBash 讓整個啟動腳本跑在 FEX 的 guest 環境裡,腳本 exec 的 x86-64 伺服器
+# 執行檔才轉譯得動。啟動參數(-port= 等)不含空白,以 $* 併成一條指令字串是安全的。
+exec FEXBash "$INSTALL_DIR/PalServer.sh -publiclobby $*"

--- a/packages/agent/src/native.ts
+++ b/packages/agent/src/native.ts
@@ -21,6 +21,28 @@ const IS_WIN = process.platform === "win32";
 export const SERVER_LAUNCHER = IS_WIN ? "PalServer.exe" : "PalServer.sh";
 const CONFIG_PLATFORM_DIR = IS_WIN ? "WindowsServer" : "LinuxServer";
 
+/** Linux ARM64(樹莓派/NanoPi/Ampere…):官方只出 x86-64 伺服器執行檔,
+ * 直接 exec 會被核心拒絕(shell 誤當腳本解析、噴 Syntax error),
+ * 必須經 x86-64→ARM64 動態轉譯器啟動。 */
+const IS_LINUX_ARM64 = process.platform === "linux" && process.arch === "arm64";
+
+/** 找 x86-64 轉譯器。首選 FEX(實測 Palworld 可跑滿速;box64 缺 x86-64
+ * libgcc_s 會啟動失敗,留作已自備函式庫者的後備)。每種都先看 agent tools
+ * 目錄(免 root 手動安裝可放這),其次 PATH(發行版套件)。
+ * FEX 另需 x86-64 rootfs:跑一次 `FEXRootFSFetcher -y -x` 抓好即可。 */
+function findX64Emulator(): string | null {
+  const candidates = [
+    path.join(DATA_DIR, "tools", "fex", "FEXInterpreter"),
+    path.join(DATA_DIR, "tools", "box64", "box64"),
+  ];
+  for (const name of ["FEXInterpreter", "box64"]) {
+    for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+      if (dir) candidates.push(path.join(dir, name));
+    }
+  }
+  return candidates.find((p) => fs.existsSync(p)) ?? null;
+}
+
 /** The dedicated-server root for an instance: an adopted install if
  * configured, otherwise the agent-managed install under instanceDir. */
 export function serverRoot(rec: InstanceRecord, ctx: DriverContext): string {
@@ -212,8 +234,17 @@ const depotDownloaderDir = () => path.join(DATA_DIR, "tools", `depotdownloader-$
  * 先落到暫存目錄、驗證 exe 存在且大小合理,再整目錄換名上位 —— 半套下載/解壓
  * (斷線、磁碟滿、防毒攔截)不會留下「看似存在其實損毀」的快取,那會讓之後
  * 每一次安裝/更新都敗在同一顆壞 exe 上(症狀:exit 0xE0434352)。 */
+/** Node 的 process.arch → DepotDownloader release asset 的 arch 後綴。
+ * macOS/Windows 官方只出 x64/arm64;linux 另有 arm(32-bit,樹莓派舊機型)。 */
+function depotDownloaderArchSuffix(platform: "windows" | "macos" | "linux"): string {
+  if (process.arch === "arm64") return "arm64";
+  if (process.arch === "arm" && platform === "linux") return "arm";
+  return "x64";
+}
+
 async function ensureDepotDownloader(): Promise<string> {
   const platform = IS_WIN ? "windows" : process.platform === "darwin" ? "macos" : "linux";
+  const arch = depotDownloaderArchSuffix(platform);
   const toolsDir = depotDownloaderDir();
   const binName = IS_WIN ? "DepotDownloader.exe" : "DepotDownloader";
   const bin = path.join(toolsDir, binName);
@@ -224,7 +255,7 @@ async function ensureDepotDownloader(): Promise<string> {
   fs.mkdirSync(tmpDir, { recursive: true });
   const url =
     `https://github.com/SteamRE/DepotDownloader/releases/download/` +
-    `DepotDownloader_${DEPOTDOWNLOADER_VERSION}/DepotDownloader-${platform}-x64.zip`;
+    `DepotDownloader_${DEPOTDOWNLOADER_VERSION}/DepotDownloader-${platform}-${arch}.zip`;
   const zipPath = path.join(tmpDir, "dd.zip");
   const res = await fetch(url);
   if (!res.ok) throw new Error(`failed to download DepotDownloader: HTTP ${res.status}`);
@@ -733,13 +764,37 @@ async function spawnServer(rec: InstanceRecord, ctx: DriverContext): Promise<voi
   // DepotDownloader(與從別處複製來的 adopt 安裝)在 Linux 不會保留可執行位元。
   if (!IS_WIN) fs.chmodSync(exe, 0o755);
 
+  // 繞過 PalServer.sh 直接啟動 shipping 時,要補做該腳本的開場工作:把 Steam 的
+  // linux64/steamclient.so 放到執行檔旁,否則伺服器載入不到 steamclient。
+  if (useShipping && !IS_WIN) {
+    const scSrc = path.join(root, "linux64", "steamclient.so");
+    const scDst = path.join(root, "Pal", "Binaries", "Linux", "steamclient.so");
+    if (fs.existsSync(scSrc) && !fs.existsSync(scDst)) fs.copyFileSync(scSrc, scDst);
+  }
+
+  // Linux ARM64:x86-64 執行檔須經轉譯器啟動(見 IS_LINUX_ARM64 註解)。
+  let spawnExe = exe;
+  let spawnArgs = args;
+  if (IS_LINUX_ARM64) {
+    const emulator = findX64Emulator();
+    if (!emulator) {
+      throw new Error(
+        "這台是 ARM64 主機,而 Palworld 官方伺服器只有 x86-64 版,需要 FEX 轉譯器才能啟動 — " +
+          `請安裝 FEX(ppa:fex-emu/fex)並跑一次 FEXRootFSFetcher -y -x 後重試;` +
+          `免 root 安裝可把 FEXInterpreter 等執行檔放到 ${path.join(DATA_DIR, "tools", "fex")}/`,
+      );
+    }
+    spawnArgs = [exe, ...args];
+    spawnExe = emulator;
+  }
+
   fs.appendFileSync(
     logFile(ctx),
-    `[palserver] starting ${useShipping ? "PalServer (shipping, 日誌已擷取)" : "PalServer launcher(找不到 shipping,遊戲日誌將為空)"}...\n`,
+    `[palserver] starting ${useShipping ? "PalServer (shipping, 日誌已擷取)" : "PalServer launcher(找不到 shipping,遊戲日誌將為空)"}${IS_LINUX_ARM64 ? "(經 x86-64 轉譯器)" : ""}...\n`,
   );
   // 遊戲 console 輸出 → game.log(每次開機重來一份,UE 本來也是一次一份)。
   const gameOut = fs.openSync(gameLogFile(ctx), "w");
-  const child = spawn(exe, args, {
+  const child = spawn(spawnExe, spawnArgs, {
     cwd: root,
     detached: true, // survives agent restarts; we track it via the pid file
     stdio: ["ignore", gameOut, gameOut],


### PR DESCRIPTION
## 動機

Palworld 官方只出 x86-64 的伺服器執行檔,ARM64 主機(樹莓派、NanoPi、Ampere 雲主機等)目前無法使用本專案。這個 PR 讓伺服器經 [FEX](https://fex-emu.com)(x86-64→ARM64 動態轉譯器)啟動,已在 NanoPi M6(RK3588)實機驗證可正常開服、進遊戲。

## 內容

分兩塊,互不相依:

**1. `images/vanilla-arm64/` — 新的 Docker 鏡像**
- Ubuntu 24.04 + FEX(PPA)+ arm64 版 DepotDownloader
- 容器介面與 `images/vanilla` 完全相同(`/data/saved`、`/data/config`、CMD 啟動參數),agent 的 docker 後端**不需任何改動**,建立實例時指定本鏡像即可
- x86-64 rootfs 在建置期抓好;`--build-arg FEX_VARIANT=armv8.0` 可支援較舊的板子(樹莓派 4 等)

**2. `packages/agent/src/native.ts` — native 後端支援**
- 偵測 linux/arm64 時自動尋找轉譯器(首選 FEXInterpreter,box64 為後備),經轉譯器啟動 shipping 執行檔
- DepotDownloader 下載改依 `process.arch` 選對 release asset(原本寫死 x64,在 ARM 上會抓錯)
- 繞過 PalServer.sh 直啟時補做 steamclient.so 的複製

## 相容性

- 所有新邏輯都在 `IS_LINUX_ARM64` 判斷之後,x86-64 / Windows / macOS 路徑行為完全不變
- FEX 下實測可跑滿速

## 實機部署紀錄

在以下 ARM64 實機上從原始碼建置並開服驗證(規格由 `lscpu`/`free -h`/`lsblk` 取得):

| 項目 | 規格 |
|---|---|
| 板子 | FriendlyElec NanoPi M6(Rockchip RK3588) |
| CPU | 4× Cortex-A76 @ 2.25 GHz + 4× Cortex-A55 @ 1.8 GHz |
| 記憶體 | 32 GB |
| 儲存 | 256 GB eMMC |
| 系統 | Ubuntu 24.04 LTS(kernel 6.1) |

建置步驟與 x86-64 完全相同,無需任何 ARM 特殊處理:

```bash
# 1. 安裝 ARM64 的 Node 20+(建議用 nvm;本機實測 v24.14)
curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
nvm install 22

# 2. 啟用 pnpm(專案指定 pnpm 11)
corepack enable
corepack prepare pnpm@11.10.0 --activate

# 3. 取得原始碼並建置
git clone https://github.com/io-software-ai/palserver-gui.git
cd palserver-gui
pnpm install
pnpm release:exe
```

## 參考與致謝

在 ARM64 上以 FEX 執行 Palworld 伺服器的作法,參考自 [nitrog0d/palworld-arm64](https://github.com/nitrog0d/palworld-arm64)(該專案驗證了 FEX 方案的可行性與 rootfs 設定方式),在此致謝。本 PR 將這套作法整合進本專案的容器介面與 agent 後端。

樂意依照你的意見調整(拆 PR、補文件、改命名都可以)。
