### PR TITLE
[codex] Fix Unicode in RCON commands and Windows logs

### DIFF
--- a/packages/agent/src/native.test.ts
+++ b/packages/agent/src/native.test.ts
@@ -1,6 +1,18 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { classifyServerExit, linesToReplay } from "./native.js";
+import { classifyServerExit, decodeWindowsLog, linesToReplay } from "./native.js";
+
+test("decodeWindowsLog: Windows GBK system error falls back from invalid UTF-8", () => {
+  assert.equal(decodeWindowsLog(Buffer.from([0xB2, 0xCE, 0xCA, 0xFD, 0xCE, 0xDE, 0xD0, 0xA7])), "参数无效");
+});
+
+test("decodeWindowsLog: mixed UTF-8 and GBK lines preserve both", () => {
+  const bytes = Buffer.concat([
+    Buffer.from("啟動完成\n", "utf8"),
+    Buffer.from([0xB2, 0xCE, 0xCA, 0xFD, 0xCE, 0xDE, 0xD0, 0xA7]),
+  ]);
+  assert.equal(decodeWindowsLog(bytes), "啟動完成\n参数无效");
+});
 
 test("linesToReplay: replay=0 不補任何歷史(slice(-0)=整包 的陷阱)", () => {
   // 這是「重啟時舊捕捉/死亡誤報」的根因:log-event-tracker 用 replay=0,必須真的回 []。

--- a/packages/agent/src/native.ts
+++ b/packages/agent/src/native.ts
@@ -802,6 +802,13 @@ async function spawnServer(rec: InstanceRecord, ctx: DriverContext): Promise<voi
   writeIni(rec, ctx);
   const root = serverRoot(rec, ctx);
 
+  // PalDefender's plain Source RCON path cannot carry Unicode reliably.
+  // Switch its transport before launch so every client and server packet agrees.
+  if (IS_WIN) {
+    const pdRest = await import("./paldefender-rest.js");
+    pdRest.preprovisionPdRconBase64(rec, ctx);
+  }
+
   const serverArgs = [
     `-port=${rec.gamePort}`,
     // 每台唯一的 Steam 查詢埠;不帶的話全部搶 27015,第二台就死在 ::bind。
@@ -1241,11 +1248,30 @@ export function newestPalDefenderLogLines(
   const file = newestFile(dir, sinceMs);
   if (!file) return [];
   try {
-    return fs.readFileSync(file, "utf8").split(/\r?\n/).filter((l) => l.trim()).slice(-n);
+    return decodeNativeLog(fs.readFileSync(file)).split(/\r?\n/).filter((l) => l.trim()).slice(-n);
   } catch {
     return [];
   }
 }
+
+/** Some Windows libraries format system errors using the active Chinese ANSI
+ * code page even when the rest of the server log is UTF-8. */
+export function decodeWindowsLog(bytes: Buffer): string {
+  const decodeLine = (line: Buffer): string => {
+    const utf8 = line.toString("utf8");
+    return utf8.includes("\uFFFD") ? new TextDecoder("gb18030").decode(line) : utf8;
+  };
+  const lines: string[] = [];
+  let start = 0;
+  for (let end = bytes.indexOf(0x0a, start); end !== -1; end = bytes.indexOf(0x0a, start)) {
+    lines.push(decodeLine(bytes.subarray(start, end)) + "\n");
+    start = end + 1;
+  }
+  if (start < bytes.length) lines.push(decodeLine(bytes.subarray(start)));
+  return lines.join("");
+}
+
+const decodeNativeLog = (bytes: Buffer): string => IS_WIN ? decodeWindowsLog(bytes) : bytes.toString("utf8");
 
 function newestFile(dir: string, sinceMs?: number): string | null {
   try {
@@ -1305,7 +1331,7 @@ export function linesToReplay(existing: string[], replay: number): string[] {
 function followFile(file: string, onLine: (line: string) => void, replay = 200): () => void {
   let attached = false;
   let position = 0;
-  let buffer = "";
+  let pending = Buffer.alloc(0);
   const timer = setInterval(() => {
     let size: number;
     try {
@@ -1317,26 +1343,29 @@ function followFile(file: string, onLine: (line: string) => void, replay = 200):
     if (!attached) {
       // replay=0(如 log-event-tracker)只跟新行,連讀檔都跳過、直接位移到檔尾;
       // replay>0(如 UI log 視窗)才讀出既有行、補送最後 replay 行。
-      const existing = replay > 0 ? fs.readFileSync(file, "utf8").split("\n").filter(Boolean) : [];
+      const existing = replay > 0 ? decodeNativeLog(fs.readFileSync(file)).split("\n").filter(Boolean) : [];
       for (const line of linesToReplay(existing, replay)) onLine(line);
       position = size;
-      buffer = "";
+      pending = Buffer.alloc(0);
       attached = true;
       return;
     }
     if (size < position) {
       // truncated or rotated in place (UE starts a fresh Pal.log per boot)
       position = 0;
-      buffer = "";
+      pending = Buffer.alloc(0);
     }
     if (size === position) return;
     const stream = fs.createReadStream(file, { start: position, end: size - 1 });
     position = size;
     stream.on("data", (chunk) => {
-      buffer += chunk.toString();
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
-      for (const line of lines) if (line.length > 0) onLine(line);
+      pending = Buffer.concat([pending, Buffer.from(chunk)]);
+      let newline: number;
+      while ((newline = pending.indexOf(0x0a)) !== -1) {
+        const line = decodeNativeLog(pending.subarray(0, newline));
+        pending = pending.subarray(newline + 1);
+        if (line.length > 0) onLine(line);
+      }
     });
   }, 500);
   return () => clearInterval(timer);

--- a/packages/agent/src/paldefender-rest.ts
+++ b/packages/agent/src/paldefender-rest.ts
@@ -257,6 +257,27 @@ export async function provisionPdToken(
   return existsInRuntime(rec, file);
 }
 
+/** Enable PalDefender's UTF-8-safe RCON transport before the server starts.
+ * Existing Config.json fields are preserved. */
+export function preprovisionPdRconBase64(rec: InstanceRecord, ctx: DriverContext): void {
+  if (rec.backend !== "native") return;
+  const win64 = path.join(serverRoot(rec, ctx), "Pal", "Binaries", "Win64");
+  const dir = PD_DIR_NAMES.map((name) => path.join(win64, name)).find((candidate) => fs.existsSync(candidate));
+  if (!dir) return;
+  const file = path.join(dir, "Config.json");
+  let config: Record<string, unknown> = {};
+  try {
+    config = JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    // Missing means PalDefender has not generated Config.json yet; malformed
+    // means leave the user's file untouched for the existing editor to report.
+    return;
+  }
+  if (config.RCONbase64 === true) return;
+  config.RCONbase64 = true;
+  fs.writeFileSync(file, JSON.stringify(config, null, 4));
+}
+
 /** 強化版建立流程用:在「首次啟動前」預先鋪好 REST 設定與 GUI 權杖。
  * PalDefender 尚未跑過、連 PalDefender/ 目錄都還沒有,所以自己建目錄寫檔;
  * PalDefender 首次開機讀到 Enabled:true 就直接把 REST API 帶起來,缺的
@@ -292,6 +313,18 @@ export function preprovisionPdRest(rec: InstanceRecord, ctx: DriverContext): voi
       JSON.stringify({ Name: "palserver GUI", Token: token, Permissions: ["REST.*"] }, null, 4),
     );
   }
+
+  const pdConfigFile = path.join(dir, "Config.json");
+  let pdConfig: Record<string, unknown> = {};
+  if (fs.existsSync(pdConfigFile)) {
+    try {
+      pdConfig = JSON.parse(fs.readFileSync(pdConfigFile, "utf8"));
+    } catch {
+      return; // Preserve malformed user config; the config UI reports it.
+    }
+  }
+  pdConfig.RCONbase64 = true;
+  fs.writeFileSync(pdConfigFile, JSON.stringify(pdConfig, null, 4));
 }
 
 /** Map PalDefender's error codes to something a manager can act on. */
@@ -349,6 +382,15 @@ async function pdFetch<T>(
     throw new PdRestError(`PalDefender 回應 HTTP ${res.status}`);
   }
   return (await res.json()) as T;
+}
+
+/** Send prominent messages through PalDefender's JSON/UTF-8 API. */
+export async function sendPdAlert(rec: InstanceRecord, ctx: DriverContext, message: string): Promise<void> {
+  const status = await getPdRestStatus(rec, ctx);
+  if (!status.enabled) throw new PdRestError(status.reason ?? "PalDefender REST API 未啟用");
+  const dir = await getPdDir(rec, ctx);
+  if (!dir) throw new PdRestError("尚未安裝 PalDefender");
+  await pdFetch<unknown>(rec, dir, "/Alert", { Message: message });
 }
 
 function collectPals(pals: Record<string, unknown> | undefined, location: PdPal["location"]): PdPal[] {

--- a/packages/agent/src/rcon.test.ts
+++ b/packages/agent/src/rcon.test.ts
@@ -1,0 +1,15 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { decodeRconBase64, encodeRconPacket } from "./rcon.js";
+
+test("RCON Base64 preserves Unicode commands and responses", () => {
+  const command = "renameplayer steam_1 中文名字";
+  const encoded = Buffer.from(command, "utf8").toString("base64");
+  const packet = encodeRconPacket(2, 2, encoded);
+  assert.equal(packet.subarray(12, -2).toString("utf8"), encoded);
+  assert.equal(decodeRconBase64(Buffer.from("醒目警示", "utf8").toString("base64")), "醒目警示");
+});
+
+test("RCON Base64 decoder leaves ordinary non-Base64 responses unchanged", () => {
+  assert.equal(decodeRconBase64("Unknown command"), "Unknown command");
+});

--- a/packages/agent/src/rcon.ts
+++ b/packages/agent/src/rcon.ts
@@ -19,13 +19,22 @@ const CONNECT_TIMEOUT_MS = 4000;
  * after the first one arrives. */
 const DRAIN_MS = 250;
 
+type RconBase64Resolver = (rec: InstanceRecord) => boolean | Promise<boolean>;
+let resolveBase64: RconBase64Resolver | null = null;
+
+/** PalDefender stores the protocol mode in Config.json. Routes install a
+ * resolver once their instance context is available. */
+export function setRconBase64Resolver(resolver: RconBase64Resolver): void {
+  resolveBase64 = resolver;
+}
+
 class RconError extends Error {
   constructor(message: string, readonly statusCode: number) {
     super(message);
   }
 }
 
-function encode(id: number, type: number, body: string): Buffer {
+export function encodeRconPacket(id: number, type: number, body: string): Buffer {
   const payload = Buffer.from(body, "utf8");
   const size = 4 + 4 + payload.length + 2;
   const buf = Buffer.allocUnsafe(4 + size);
@@ -36,6 +45,12 @@ function encode(id: number, type: number, body: string): Buffer {
   buf.writeUInt8(0, 12 + payload.length);
   buf.writeUInt8(0, 13 + payload.length);
   return buf;
+}
+
+export function decodeRconBase64(body: string): string {
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(body) || body.length % 4 !== 0) return body;
+  const decoded = Buffer.from(body, "base64").toString("utf8");
+  return decoded.includes("\uFFFD") ? body : decoded;
 }
 
 interface Packet {
@@ -79,10 +94,15 @@ function rconHost(rec: InstanceRecord): string {
 
 /** `async` so a disabled-RCON instance rejects instead of throwing
  * synchronously — callers attach .catch() and would otherwise be bypassed. */
-export async function rconExec(rec: InstanceRecord, command: string): Promise<string> {
+export async function rconExec(
+  rec: InstanceRecord,
+  command: string,
+  options?: { base64?: boolean },
+): Promise<string> {
   requireRcon(rec);
   const port = Number(rec.settings.RCONPort);
   const password = String(rec.settings.AdminPassword);
+  const useBase64 = options?.base64 ?? (resolveBase64 ? await resolveBase64(rec) : false);
 
   return new Promise<string>((resolve, reject) => {
     const socket = net.createConnection({ host: rconHost(rec), port });
@@ -102,7 +122,7 @@ export async function rconExec(rec: InstanceRecord, command: string): Promise<st
       err ? reject(err) : resolve(value);
     };
 
-    socket.on("connect", () => socket.write(encode(1, TYPE_AUTH, password)));
+    socket.on("connect", () => socket.write(encodeRconPacket(1, TYPE_AUTH, password)));
 
     socket.on("data", (chunk) => {
       tail = decode(Buffer.concat([tail, chunk]), packets);
@@ -116,18 +136,20 @@ export async function rconExec(rec: InstanceRecord, command: string): Promise<st
         }
         authed = true;
         packets.length = 0;
-        socket.write(encode(2, TYPE_EXEC, command));
+        const body = useBase64 ? Buffer.from(command, "utf8").toString("base64") : command;
+        socket.write(encodeRconPacket(2, TYPE_EXEC, body));
         return;
       }
 
       // Collect response packets, then settle once they stop arriving.
       if (drainTimer) clearTimeout(drainTimer);
       drainTimer = setTimeout(() => {
-        const body = packets
+        const rawBody = packets
           .filter((p) => p.type === TYPE_RESPONSE)
           .map((p) => p.body)
           .join("")
           .trim();
+        const body = useBase64 ? decodeRconBase64(rawBody) : rawBody;
         finish(null, body);
       }, DRAIN_MS);
     });

--- a/packages/agent/src/routes.ts
+++ b/packages/agent/src/routes.ts
@@ -28,7 +28,7 @@ import {
   type RconCommandsResponse,
   type DirEntry,
 } from "@palserver/shared";
-import { fetchServerCommands, rconExec, requireRcon } from "./rcon.js";
+import { fetchServerCommands, rconExec, requireRcon, setRconBase64Resolver } from "./rcon.js";
 import type { PresenceTracker } from "./presence.js";
 import type { BackupScheduler } from "./backup-scheduler.js";
 import type { RestartSupervisor } from "./supervisor.js";
@@ -98,7 +98,7 @@ import {
   restoreConfigSnapshot,
 } from "./config-backup.js";
 import { getPalDefenderConfig, writePalDefenderConfig } from "./paldefender-config.js";
-import { getPlayerDetail, getPdPlayers, getPdGuilds, getPdGuild, getPdRestStatus, setPdRestEnabled, setPdRestPort, provisionPdToken } from "./paldefender-rest.js";
+import { getPlayerDetail, getPdPlayers, getPdGuilds, getPdGuild, getPdRestStatus, setPdRestEnabled, setPdRestPort, provisionPdToken, sendPdAlert } from "./paldefender-rest.js";
 import { setTelemetryEnabled, telemetryStatus, track } from "./telemetry.js";
 import { licenseStatus, setLicenseKey, clearLicenseKey, featureEnabled } from "./license.js";
 import { giveCustomPal } from "./pals.js";
@@ -262,6 +262,11 @@ export function registerRoutes(
 ): void {
   const ctxOf = (rec: InstanceRecord): DriverContext => ({
     instanceDir: store.instanceDir(rec.id),
+  });
+  setRconBase64Resolver(async (rec) => {
+    const mod = (await getModsStatus(rec, ctxOf(rec))).paldefender;
+    if (!mod.installed || mod.enabled === false) return false;
+    return (await getPalDefenderConfig(rec, ctxOf(rec))).values.RCONbase64 === true;
   });
   const snapshotBefore = async (rec: InstanceRecord, reason: string): Promise<void> => {
     if (rec.backend === "docker") return;
@@ -1277,6 +1282,7 @@ export function registerRoutes(
           await pd.preConfigureRestApi(rec, ctxOf(rec), newPort).catch(() => {});
           // Create token file (PD reads Tokens/ dir on boot).
           await pd.provisionPdToken(rec, ctxOf(rec), false).catch(() => {});
+          pd.preprovisionPdRconBase64(rec, ctxOf(rec));
         }
       } catch { /* PD config is best-effort */ }
     }
@@ -1585,6 +1591,11 @@ export function registerRoutes(
   app.post("/api/instances/:id/rcon", async (req) => {
     const rec = getOr404((req.params as { id: string }).id);
     const { command } = z.object({ command: z.string().min(1).max(500) }).parse(req.body);
+    const alert = /^\/?alert\s+([\s\S]+)$/i.exec(command);
+    if (alert) {
+      await sendPdAlert(rec, ctxOf(rec), alert[1]);
+      return { command, output: "OK" };
+    }
     const output = await rconExec(rec, command);
     return { command, output };
   });
@@ -1709,6 +1720,7 @@ export function registerRoutes(
 
   app.put("/api/instances/:id/paldefender-config", async (req) => {
     const rec = getOr404((req.params as { id: string }).id);
+    const previous = await getPalDefenderConfig(rec, ctxOf(rec));
     const shape = Object.fromEntries(
       Object.entries(PALDEFENDER_OPTIONS).map(([key, meta]) => {
         if (meta.type === "bool") return [key, z.boolean().optional()];
@@ -1725,7 +1737,8 @@ export function registerRoutes(
       .parse(req.body);
     const status = await writePalDefenderConfig(rec, ctxOf(rec), patch as PalDefenderConfigPatch);
     // Try to hot-apply without a restart; harmless if RCON is off.
-    await rconExec(rec, "reloadcfg").catch(() => {});
+    // The server still speaks the previous mode until reloadcfg completes.
+    await rconExec(rec, "reloadcfg", { base64: previous.values.RCONbase64 === true }).catch(() => {});
     return { ...status, applied: "reloaded" };
   });
 

--- a/packages/shared/src/paldefender-options.ts
+++ b/packages/shared/src/paldefender-options.ts
@@ -93,6 +93,7 @@ export const PALDEFENDER_OPTIONS = {
   OilrigGoalBoxLocktime: { type: "int", default: 300, min: 0, max: 3600, category: "misc", label: "鑽油平台目標寶箱鎖定時間(秒)" },
   RCONTimeout: { type: "float", default: 5, min: 1, max: 60, step: 0.5, category: "misc", label: "RCON 連線逾時(秒)" },
   RCONUsePacketIdFix: { type: "bool", default: false, category: "misc", label: "修正 RCON 封包 ID 問題" },
+  RCONbase64: { type: "bool", default: true, category: "misc", label: "使用 Base64 RCON 文字編碼", hint: "讓 RCON 指令可安全傳送中文、日文與其他非 ASCII 文字。" },
 } as const satisfies Record<string, PdOptionMeta>;
 
 export type PdOptionKey = keyof typeof PALDEFENDER_OPTIONS;


### PR DESCRIPTION
## What changed

- enable PalDefender's Base64 RCON transport so commands such as `renameplayer` preserve Chinese, Japanese, and other Unicode text
- route `/alert` through PalDefender's UTF-8 REST endpoint
- decode Windows server logs line-by-line with a GB18030 fallback when output is not valid UTF-8
- automatically migrate existing native PalDefender configurations on the next server start

## Root cause

Plain Source RCON does not reliably carry Unicode through PalDefender, while some Windows system error text is emitted using the active ANSI code page even when the surrounding log is UTF-8.

Closes #50.

## Validation

- `pnpm --filter @palserver/shared build`
- `pnpm --filter @palserver/agent typecheck`
- `pnpm --filter @palserver/web typecheck`
- all Agent Node tests pass, including new Unicode RCON and mixed-encoding log coverage
