### PR TITLE
fix(agent): 避免模组下载触发 GitHub API 限流

### DIFF
--- a/packages/agent/src/boss-reporter.test.ts
+++ b/packages/agent/src/boss-reporter.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fetchRemoteBossLua, versionFromReleaseUrl } from "./boss-reporter.js";
+
+test("parses the release tag from a main.lua asset URL", () => {
+  assert.equal(
+    versionFromReleaseUrl(
+      "https://github.com/io-software-ai/palserver-boss-reporter/releases/download/v1.6/main.lua",
+    ),
+    "1.6",
+  );
+});
+
+test("downloads main.lua through latest/download without using the GitHub API", async () => {
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+    calls.push(url);
+    if (url.endsWith("/releases/latest/download/main.lua")) {
+      assert.equal(init?.redirect, "manual");
+      return new Response(null, {
+        status: 302,
+        headers: {
+          location:
+            "https://github.com/io-software-ai/palserver-boss-reporter/releases/download/1.6/main.lua",
+        },
+      });
+    }
+    if (url.endsWith("/releases/download/1.6/main.lua")) {
+      return new Response("-- PalserverBossReporter\nreturn {}", { status: 200 });
+    }
+    throw new Error(`unexpected request: ${url}`);
+  };
+
+  try {
+    const result = await fetchRemoteBossLua();
+    assert.equal(result?.version, "1.6");
+    assert.match(result?.lua ?? "", /PalserverBossReporter/);
+    assert.equal(calls.some((url) => url.includes("api.github.com")), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/agent/src/boss-reporter.ts
+++ b/packages/agent/src/boss-reporter.ts
@@ -32,9 +32,10 @@ const BOSS_MARKER_REL = `${WIN64_REL}/.palserver-boss-reporter.json`;
 
 /**
  * 遠端交付:boss-reporter Lua 的原始碼在獨立 repo(io-software-ai/palserver-boss-reporter)管理,
- * agent 安裝時抓其 GitHub Release 最新版的 main.lua(沿用 mods.ts 的 GitHub Releases 模式),
+ * agent 安裝時抓其 GitHub Release 最新版的 main.lua,
  * 讓 mod 修正不必等 GUI 改版就能送達。**不再內嵌於 agent**——抓不到(無網路 / repo 或 release
- * 尚未建立 / rate limit)就讓安裝失敗並提示,不做內嵌 fallback。repo 與直接下載 URL 皆可 env 覆寫。
+ * 尚未建立)就讓安裝失敗並提示,不做內嵌 fallback。repo 與直接下載 URL 皆可 env 覆寫。
+ * 優先走 GitHub 的 latest/download 直鏈,避免匿名 REST API 每小時 60 次的共享 IP 限流。
  */
 const BOSS_REPORTER_REPO = process.env.PALSERVER_BOSS_REPORTER_REPO || "io-software-ai/palserver-boss-reporter";
 const BOSS_REPORTER_URL_OVERRIDE = process.env.PALSERVER_BOSS_REPORTER_URL; // 直接指定 main.lua 下載 URL
@@ -46,11 +47,43 @@ interface GhRelease {
   assets: { name: string; browser_download_url: string }[];
 }
 
+function latestBossReporterAssetUrl(): string {
+  return `https://github.com/${BOSS_REPORTER_REPO}/releases/latest/download/main.lua`;
+}
+
+export function versionFromReleaseUrl(url: string): string | null {
+  const match = url.match(/\/releases\/download\/([^/]+)\/main\.lua(?:[?#]|$)/i);
+  return match ? stripV(decodeURIComponent(match[1])) : null;
+}
+
+/**
+ * latest/download 會先 302 到 /releases/download/<tag>/main.lua。手動接住第一跳即可同時取得
+ * 實際資產 URL 與版本,全程不消耗 GitHub REST API 配額。
+ */
+export async function resolveLatestBossReporterAsset(): Promise<{ url: string; version: string | null } | null> {
+  const latestUrl = latestBossReporterAssetUrl();
+  try {
+    const res = await fetch(latestUrl, { headers: { "user-agent": "palserver-gui" }, redirect: "manual" });
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get("location");
+      if (!location) return null;
+      const url = new URL(location, latestUrl).toString();
+      return { url, version: versionFromReleaseUrl(url) };
+    }
+    return res.ok ? { url: latestUrl, version: versionFromReleaseUrl(res.url) } : null;
+  } catch {
+    return null;
+  }
+}
+
 /** 最新版查詢:6h 記憶體快取、非阻塞——冷取回 null 並在背景刷新,不拖慢 status 輪詢。 */
 let latestCache: { tag: string | null; at: number } | null = null;
 let latestRefreshing = false;
 const LATEST_TTL = 6 * 60 * 60 * 1000;
 async function fetchLatestBossReporterTag(): Promise<string | null> {
+  const direct = await resolveLatestBossReporterAsset();
+  if (direct?.version) return direct.version;
+  // 非標準 Release/資產名稱才回退 API;正常 main.lua 發布完全不消耗 API 配額。
   try {
     const res = await fetch(`https://api.github.com/repos/${BOSS_REPORTER_REPO}/releases/latest`, {
       headers: GH_HEADERS,
@@ -71,21 +104,27 @@ function latestBossReporterVersion(): string | null {
   return latestCache?.tag ?? null; // 冷啟第一次回舊值(或 null),下次輪詢就有
 }
 
-/** 抓遠端最新 Lua(release 的 *.lua 資產);抓不到/內容不對回 null 讓呼叫端退回內嵌。 */
-async function fetchRemoteBossLua(): Promise<{ lua: string; version: string } | null> {
+/** 抓遠端最新 Lua;latest/download 直鏈優先,非標準資產名稱才回退 Releases API。 */
+export async function fetchRemoteBossLua(): Promise<{ lua: string; version: string } | null> {
   try {
     let url = BOSS_REPORTER_URL_OVERRIDE;
     let version = "custom";
     if (!url) {
-      const res = await fetch(`https://api.github.com/repos/${BOSS_REPORTER_REPO}/releases/latest`, {
-        headers: GH_HEADERS,
-      });
-      if (!res.ok) return null;
-      const rel = (await res.json()) as GhRelease;
-      const asset = rel.assets.find((a) => /\.lua$/i.test(a.name));
-      if (!asset) return null;
-      url = asset.browser_download_url;
-      version = stripV(rel.tag_name);
+      const direct = await resolveLatestBossReporterAsset();
+      if (direct) {
+        url = direct.url;
+        version = direct.version ?? "latest";
+      } else {
+        const res = await fetch(`https://api.github.com/repos/${BOSS_REPORTER_REPO}/releases/latest`, {
+          headers: GH_HEADERS,
+        });
+        if (!res.ok) return null;
+        const rel = (await res.json()) as GhRelease;
+        const asset = rel.assets.find((a) => /\.lua$/i.test(a.name));
+        if (!asset) return null;
+        url = asset.browser_download_url;
+        version = stripV(rel.tag_name);
+      }
     }
     const luaRes = await fetch(url, { headers: { "user-agent": "palserver-gui" } });
     if (!luaRes.ok) return null;

--- a/packages/agent/src/mods-download.test.ts
+++ b/packages/agent/src/mods-download.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveFixedTagDownload } from "./mods.js";
+
+test("resolves the fixed UE4SS asset without using the GitHub API", async () => {
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+    calls.push(url);
+    assert.equal(init?.method, "HEAD");
+    return new Response(null, {
+      status: 200,
+      headers: { "last-modified": "Sun, 19 Jul 2026 07:14:13 GMT" },
+    });
+  };
+
+  try {
+    const result = await resolveFixedTagDownload("ue4ss", "stable");
+    assert.deepEqual(result, {
+      version: "experimental-palworld (2026-07-19)",
+      url: "https://github.com/Okaetsu/RE-UE4SS/releases/download/experimental-palworld/UE4SS-Palworld.zip",
+    });
+    assert.equal(calls.some((url) => url.includes("api.github.com")), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/agent/src/mods.ts
+++ b/packages/agent/src/mods.ts
@@ -23,7 +23,15 @@ import { execInPod, readFileInPod, writeFileBytesInPod, makeDirInPod, deletePath
 
 const GH_REPOS: Record<
   ModComponent,
-  { repo: string; asset: RegExp; betaAsset?: RegExp; tag?: string; envUrl: string }
+  {
+    repo: string;
+    asset: RegExp;
+    assetName?: string;
+    betaAsset?: RegExp;
+    betaAssetName?: string;
+    tag?: string;
+    envUrl: string;
+  }
 > = {
   ue4ss: {
     // Palworld 專用的 Okaetsu fork(experimental-palworld);與 PalSchema 用的同一份,
@@ -31,7 +39,9 @@ const GH_REPOS: Record<
     repo: "Okaetsu/RE-UE4SS",
     tag: "experimental-palworld",
     asset: /^UE4SS-Palworld\.zip$/i, // 標準版
+    assetName: "UE4SS-Palworld.zip",
     betaAsset: /^UE4SS-Palworld_zDev\.zip$/i, // 開發版(含除錯主控台/工具,體積較大)
+    betaAssetName: "UE4SS-Palworld_zDev.zip",
     envUrl: "PALSERVER_UE4SS_URL",
   },
   paldefender: {
@@ -320,6 +330,36 @@ function releaseVersion(component: ModComponent, release: GitRelease): string {
   return release.tag_name;
 }
 
+/**
+ * 固定 tag 資產可直接下載,不需要 GitHub REST API。HEAD 跟隨到 CDN 後用 Last-Modified
+ * 保留原本的建置日期版本判斷;直鏈不存在才回 null 讓呼叫端走 API 相容路徑。
+ */
+export async function resolveFixedTagDownload(
+  component: ModComponent,
+  channel: "stable" | "beta",
+): Promise<{ version: string; url: string } | null> {
+  const cfg = GH_REPOS[component];
+  if (!cfg.tag) return null;
+  const assetName = channel === "beta" ? (cfg.betaAssetName ?? cfg.assetName) : cfg.assetName;
+  if (!assetName) return null;
+  const url = `https://github.com/${cfg.repo}/releases/download/${encodeURIComponent(cfg.tag)}/${encodeURIComponent(assetName)}`;
+  try {
+    const res = await fetch(url, {
+      method: "HEAD",
+      redirect: "follow",
+      headers: { "user-agent": "palserver-gui" },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!res.ok) return null;
+    const modified = res.headers.get("last-modified");
+    const timestamp = modified ? Date.parse(modified) : NaN;
+    const date = Number.isFinite(timestamp) ? new Date(timestamp).toISOString().slice(0, 10) : null;
+    return { version: date ? `${cfg.tag} (${date})` : cfg.tag, url };
+  } catch {
+    return null;
+  }
+}
+
 /** 各元件的最新穩定版 tag(6 小時記憶體快取;查詢失敗回 null,不丟錯)。
  *  給「有新版可更新」徽章用 —— 改版日玩家最需要知道模組能不能更了。 */
 const latestCache = new Map<ModComponent, { tag: string | null; at: number }>();
@@ -334,6 +374,14 @@ export async function latestModVersions(): Promise<Record<ModComponent, string |
     }
     try {
       const cfg = GH_REPOS[component];
+      if (cfg.tag) {
+        const direct = await resolveFixedTagDownload(component, "stable");
+        if (direct) {
+          latestCache.set(component, { tag: direct.version, at: Date.now() });
+          out[component] = direct.version;
+          continue;
+        }
+      }
       // 固定 tag 的元件(如 UE4SS Okaetsu fork)直接查該 tag,否則查 latest。
       const endpoint = cfg.tag
         ? `https://api.github.com/repos/${cfg.repo}/releases/tags/${cfg.tag}`
@@ -359,6 +407,9 @@ async function resolveDownload(
   const { repo, asset, betaAsset, tag, envUrl } = GH_REPOS[component];
   const override = process.env[envUrl];
   if (override) return { version: "custom", url: override };
+
+  const direct = await resolveFixedTagDownload(component, channel);
+  if (direct) return direct;
 
   // 固定 tag 的元件(UE4SS Okaetsu fork = experimental-palworld)兩個通道都用同一 release,
   // 靠不同資產區分(stable=標準版、beta=zDev 開發版)。否則:stable="latest"(排除 pre-release)、


### PR DESCRIPTION
## 修改内容

- 头目回报模组优先通过 GitHub `releases/latest/download/main.lua` 下载
- 从 Release 重定向地址解析实际版本号
- UE4SS 固定 Tag 直接使用 Release 资源地址下载
- 通过 `HEAD` 请求读取资源更新时间，保留版本日期显示
- 仅在直接下载不可用时回退 GitHub Releases API

## 修复问题

- 修复头目回报模组下载失败的问题
- 修复 UE4SS 下载出现 `HTTP 403` 的问题
- 避免匿名 GitHub API 每小时 60 次的共享 IP 限流

## 验证

- 新增头目回报模组直链下载测试
- 新增 UE4SS 固定 Tag 下载测试
- 已验证头目回报模组 `1.6` 可正常下载
- 已验证 UE4SS ZIP 可正常下载并通过 ZIP 格式检查