### PR TITLE
fix(players): 修复离线玩家重复显示并支持多平台 ID

### DIFF
--- a/packages/agent/src/player-roster.test.ts
+++ b/packages/agent/src/player-roster.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { KnownPlayer, PdPlayerSummary } from "@palserver/shared";
+import { mergeKnownPlayers } from "./player-roster.js";
+
+const known = (patch: Partial<KnownPlayer> & Pick<KnownPlayer, "userId" | "name">): KnownPlayer => ({
+  accountName: "",
+  online: false,
+  firstSeen: "2026-07-01T00:00:00.000Z",
+  lastSeen: "2026-07-20T00:00:00.000Z",
+  sessions: 3,
+  playtimeSeconds: 3600,
+  lastLevel: 10,
+  ...patch,
+});
+
+const pd = (patch: Partial<PdPlayerSummary> & Pick<PdPlayerSummary, "userId" | "name">): PdPlayerSummary => ({
+  playerUid: "",
+  guildName: "",
+  online: false,
+  ip: "",
+  ...patch,
+});
+
+test("mergeKnownPlayers merges PalDefender entries with missing UserId by unique name", () => {
+  const result = mergeKnownPlayers(
+    [
+      known({ userId: "steam_76561198000000001", name: "Alice", lastLevel: 42 }),
+      known({ userId: "steam_76561198000000002", name: "Bob", lastLevel: 21 }),
+    ],
+    [
+      pd({ userId: "", name: "Alice", guildName: "Builders" }),
+      pd({ userId: "", name: "Bob", guildName: "Explorers" }),
+    ],
+  );
+
+  assert.equal(result.length, 2);
+  assert.deepEqual(result.map((player) => player.userId), [
+    "steam_76561198000000001",
+    "steam_76561198000000002",
+  ]);
+  assert.deepEqual(result.map((player) => player.guildName), ["Builders", "Explorers"]);
+  assert.deepEqual(result.map((player) => player.lastLevel), [42, 21]);
+});
+
+test("mergeKnownPlayers matches Steam IDs with and without the steam_ prefix", () => {
+  const result = mergeKnownPlayers(
+    [known({ userId: "steam_76561198000000001", name: "Old name", sessions: 8 })],
+    [pd({ userId: "76561198000000001", name: "Current name", online: true })],
+  );
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.userId, "steam_76561198000000001");
+  assert.equal(result[0]?.name, "Current name");
+  assert.equal(result[0]?.online, true);
+  assert.equal(result[0]?.sessions, 8);
+});
+
+test("mergeKnownPlayers omits unidentifiable PalDefender-only entries", () => {
+  const result = mergeKnownPlayers(
+    [known({ userId: "steam_76561198000000001", name: "Alice" })],
+    [pd({ userId: "", name: "Unknown" })],
+  );
+
+  assert.deepEqual(result.map((player) => player.name), ["Alice"]);
+});
+
+test("mergeKnownPlayers does not guess when names are ambiguous", () => {
+  const result = mergeKnownPlayers(
+    [
+      known({ userId: "steam_76561198000000001", name: "Same name" }),
+      known({ userId: "steam_76561198000000002", name: "Same name" }),
+    ],
+    [pd({ userId: "", name: "Same name", guildName: "Guild" })],
+  );
+
+  assert.equal(result.length, 2);
+  assert.equal(result.every((player) => player.guildName === undefined), true);
+});

--- a/packages/agent/src/player-roster.test.ts
+++ b/packages/agent/src/player-roster.test.ts
@@ -56,6 +56,42 @@ test("mergeKnownPlayers matches Steam IDs with and without the steam_ prefix", (
   assert.equal(result[0]?.sessions, 8);
 });
 
+test("mergeKnownPlayers matches GDK and PS5 IDs with and without platform prefixes", () => {
+  const result = mergeKnownPlayers(
+    [
+      known({ userId: "gdk_2533274963232060", name: "Xbox player", sessions: 5 }),
+      known({ userId: "ps5_4877707100835767776", name: "PlayStation player", sessions: 7 }),
+    ],
+    [
+      pd({ userId: "2533274963232060", name: "Xbox player", online: true }),
+      pd({ userId: "4877707100835767776", name: "PlayStation player", online: false }),
+    ],
+  );
+
+  assert.equal(result.length, 2);
+  assert.deepEqual(result.map((player) => player.userId), [
+    "gdk_2533274963232060",
+    "ps5_4877707100835767776",
+  ]);
+  assert.deepEqual(result.map((player) => player.sessions), [5, 7]);
+});
+
+test("mergeKnownPlayers keeps different platforms separate when numeric IDs coincide", () => {
+  const result = mergeKnownPlayers(
+    [
+      known({ userId: "gdk_1234567890123456", name: "Xbox player" }),
+      known({ userId: "ps5_1234567890123456", name: "PlayStation player" }),
+    ],
+    [pd({ userId: "1234567890123456", name: "Unknown platform" })],
+  );
+
+  assert.equal(result.length, 2);
+  assert.deepEqual(result.map((player) => player.userId), [
+    "gdk_1234567890123456",
+    "ps5_1234567890123456",
+  ]);
+});
+
 test("mergeKnownPlayers omits unidentifiable PalDefender-only entries", () => {
   const result = mergeKnownPlayers(
     [known({ userId: "steam_76561198000000001", name: "Alice" })],

--- a/packages/agent/src/player-roster.ts
+++ b/packages/agent/src/player-roster.ts
@@ -1,11 +1,51 @@
 import type { KnownPlayer, PdPlayerSummary } from "@palserver/shared";
 
-const identityKey = (userId: string): string => {
-  const value = userId.trim().toLowerCase();
-  return value.startsWith("steam_") ? value.slice("steam_".length) : value;
+interface PlayerIdentity {
+  exact: string;
+  platform?: string;
+  numeric?: string;
+}
+
+const playerIdentity = (userId: string): PlayerIdentity => {
+  const exact = userId.trim().toLowerCase();
+  const prefixed = exact.match(/^([a-z][a-z0-9-]*)_(\d+)$/);
+  if (prefixed) return { exact, platform: prefixed[1], numeric: prefixed[2] };
+  return { exact, ...(exact.match(/^\d+$/) ? { numeric: exact } : {}) };
 };
 
 const nameKey = (name: string): string => name.trim().replace(/\s+/g, " ").toLowerCase();
+
+const identitiesMatch = (left: PlayerIdentity, right: PlayerIdentity): boolean =>
+  left.exact === right.exact ||
+  Boolean(
+    left.numeric &&
+    left.numeric === right.numeric &&
+    (!left.platform || !right.platform),
+  );
+
+function matchingIndices(
+  players: KnownPlayer[],
+  identity: PlayerIdentity,
+  playerName: string,
+): number[] {
+  const exact = players
+    .map((player, index) => ({ identity: playerIdentity(player.userId), index }))
+    .filter((candidate) => candidate.identity.exact === identity.exact)
+    .map((candidate) => candidate.index);
+  if (exact.length) return exact;
+
+  const compatible = players
+    .map((player, index) => ({ player, identity: playerIdentity(player.userId), index }))
+    .filter((candidate) => identitiesMatch(candidate.identity, identity));
+  if (compatible.length <= 1) return compatible.map((candidate) => candidate.index);
+
+  const name = nameKey(playerName);
+  if (!name) return compatible.map((candidate) => candidate.index);
+  const named = compatible.filter((candidate) => nameKey(candidate.player.name) === name);
+  return named.length === 1
+    ? named.map((candidate) => candidate.index)
+    : compatible.map((candidate) => candidate.index);
+}
 
 function mergePlayer(player: PdPlayerSummary, previous?: KnownPlayer): KnownPlayer {
   return {
@@ -36,16 +76,19 @@ export function mergeKnownPlayers(
 ): KnownPlayer[] {
   const remaining = [...ownPlayers];
   const merged: KnownPlayer[] = [];
-  const seenIds = new Set<string>();
-  const missingId = pdPlayers.filter((player) => !identityKey(player.userId));
+  const missingId = pdPlayers.filter((player) => !playerIdentity(player.userId).exact);
 
   for (const player of pdPlayers) {
-    const id = identityKey(player.userId);
-    if (!id || seenIds.has(id)) continue;
-    const previousIndex = remaining.findIndex((candidate) => identityKey(candidate.userId) === id);
-    const previous = previousIndex >= 0 ? remaining.splice(previousIndex, 1)[0] : undefined;
+    const identity = playerIdentity(player.userId);
+    if (!identity.exact || matchingIndices(merged, identity, player.name).length) continue;
+    const previousMatches = matchingIndices(remaining, identity, player.name);
+    // A bare numeric ID can match multiple platforms. Do not guess or add a
+    // third representation when the platform cannot be determined safely.
+    if (previousMatches.length > 1) continue;
+    const previous = previousMatches.length === 1
+      ? remaining.splice(previousMatches[0], 1)[0]
+      : undefined;
     merged.push(mergePlayer(player, previous));
-    seenIds.add(id);
   }
 
   const pdNameCounts = new Map<string, number>();
@@ -62,18 +105,18 @@ export function mergeKnownPlayers(
       .filter(({ candidate }) => nameKey(candidate.name) === name);
     if (matches.length !== 1) continue;
     const [{ candidate, index }] = matches;
-    const id = identityKey(candidate.userId);
-    if (!id || seenIds.has(id)) continue;
+    const identity = playerIdentity(candidate.userId);
+    if (!identity.exact || matchingIndices(merged, identity, candidate.name).length) continue;
     remaining.splice(index, 1);
     merged.push(mergePlayer(player, candidate));
-    seenIds.add(id);
   }
 
+  const seenExactIds = new Set(merged.map((player) => playerIdentity(player.userId).exact));
   for (const player of remaining) {
-    const id = identityKey(player.userId);
-    if (!id || seenIds.has(id)) continue;
+    const id = playerIdentity(player.userId).exact;
+    if (!id || seenExactIds.has(id)) continue;
     merged.push(player);
-    seenIds.add(id);
+    seenExactIds.add(id);
   }
   return merged;
 }

--- a/packages/agent/src/player-roster.ts
+++ b/packages/agent/src/player-roster.ts
@@ -1,0 +1,79 @@
+import type { KnownPlayer, PdPlayerSummary } from "@palserver/shared";
+
+const identityKey = (userId: string): string => {
+  const value = userId.trim().toLowerCase();
+  return value.startsWith("steam_") ? value.slice("steam_".length) : value;
+};
+
+const nameKey = (name: string): string => name.trim().replace(/\s+/g, " ").toLowerCase();
+
+function mergePlayer(player: PdPlayerSummary, previous?: KnownPlayer): KnownPlayer {
+  return {
+    userId: previous?.userId ?? player.userId.trim(),
+    name: player.name.trim() || previous?.name || "",
+    accountName: previous?.accountName ?? "",
+    online: player.online,
+    firstSeen: previous?.firstSeen ?? "",
+    lastSeen: previous?.lastSeen ?? "",
+    sessions: previous?.sessions ?? 0,
+    playtimeSeconds: previous?.playtimeSeconds ?? 0,
+    lastLevel: previous?.lastLevel ?? 0,
+    ...(player.guildName.trim() ? { guildName: player.guildName.trim() } : {}),
+  };
+}
+
+/**
+ * Merge PalDefender's save-backed roster with the agent's presence history.
+ *
+ * PalDefender documents UserId as optional for offline save entries. Those
+ * entries cannot be keyed directly, so use a unique player name as a guarded
+ * fallback. Ambiguous or unknown nameless-ID entries are omitted because a
+ * KnownPlayer without a UserId cannot be targeted by any player action.
+ */
+export function mergeKnownPlayers(
+  ownPlayers: KnownPlayer[],
+  pdPlayers: PdPlayerSummary[],
+): KnownPlayer[] {
+  const remaining = [...ownPlayers];
+  const merged: KnownPlayer[] = [];
+  const seenIds = new Set<string>();
+  const missingId = pdPlayers.filter((player) => !identityKey(player.userId));
+
+  for (const player of pdPlayers) {
+    const id = identityKey(player.userId);
+    if (!id || seenIds.has(id)) continue;
+    const previousIndex = remaining.findIndex((candidate) => identityKey(candidate.userId) === id);
+    const previous = previousIndex >= 0 ? remaining.splice(previousIndex, 1)[0] : undefined;
+    merged.push(mergePlayer(player, previous));
+    seenIds.add(id);
+  }
+
+  const pdNameCounts = new Map<string, number>();
+  for (const player of missingId) {
+    const name = nameKey(player.name);
+    if (name) pdNameCounts.set(name, (pdNameCounts.get(name) ?? 0) + 1);
+  }
+
+  for (const player of missingId) {
+    const name = nameKey(player.name);
+    if (!name || pdNameCounts.get(name) !== 1) continue;
+    const matches = remaining
+      .map((candidate, index) => ({ candidate, index }))
+      .filter(({ candidate }) => nameKey(candidate.name) === name);
+    if (matches.length !== 1) continue;
+    const [{ candidate, index }] = matches;
+    const id = identityKey(candidate.userId);
+    if (!id || seenIds.has(id)) continue;
+    remaining.splice(index, 1);
+    merged.push(mergePlayer(player, candidate));
+    seenIds.add(id);
+  }
+
+  for (const player of remaining) {
+    const id = identityKey(player.userId);
+    if (!id || seenIds.has(id)) continue;
+    merged.push(player);
+    seenIds.add(id);
+  }
+  return merged;
+}

--- a/packages/agent/src/routes.ts
+++ b/packages/agent/src/routes.ts
@@ -99,6 +99,7 @@ import {
 } from "./config-backup.js";
 import { getPalDefenderConfig, writePalDefenderConfig } from "./paldefender-config.js";
 import { getPlayerDetail, getPdPlayers, getPdGuilds, getPdGuild, getPdRestStatus, setPdRestEnabled, setPdRestPort, provisionPdToken, deleteBase } from "./paldefender-rest.js";
+import { mergeKnownPlayers } from "./player-roster.js";
 import { setTelemetryEnabled, telemetryStatus, track } from "./telemetry.js";
 import { licenseStatus, setLicenseKey, clearLicenseKey, featureEnabled } from "./license.js";
 import { giveCustomPal } from "./pals.js";
@@ -1483,25 +1484,7 @@ export function registerRoutes(
     const own = presence.knownPlayers(rec.id);
     const pd = await getPdPlayers(rec, ctxOf(rec));
     if (!pd.available) return own;
-    const byId = new Map(own.map((p) => [p.userId, p]));
-    const merged: KnownPlayer[] = pd.players.map((p) => {
-      const prev = byId.get(p.userId);
-      byId.delete(p.userId);
-      return {
-        userId: p.userId,
-        name: p.name || prev?.name || "",
-        accountName: prev?.accountName ?? "",
-        online: p.online,
-        firstSeen: prev?.firstSeen ?? "",
-        lastSeen: prev?.lastSeen ?? "",
-        sessions: prev?.sessions ?? 0,
-        playtimeSeconds: prev?.playtimeSeconds ?? 0,
-        lastLevel: prev?.lastLevel ?? 0,
-        ...(p.guildName ? { guildName: p.guildName } : {}),
-      };
-    });
-    for (const leftover of byId.values()) merged.push(leftover);
-    return merged;
+    return mergeKnownPlayers(own, pd.players);
   };
 
   app.get("/api/instances/:id/players/known", async (req) => {


### PR DESCRIPTION
## 问题

PalDefender 的离线玩家记录可能出现以下情况：

- `UserId` 为空
- ID 带有 `steam_`、`gdk_`、`ps5_` 等平台前缀
- 同一 ID 在不同数据源中分别以带前缀和裸数字形式出现

原有逻辑仅按原始 `UserId` 合并，无法匹配这些记录，导致同一批离线玩家被再次追加，离线玩家数量接近翻倍。

## 修复

- 优先使用完整平台 ID 精确匹配
- 支持 `steam_`、`gdk_`、`ps5_` 及其他平台前缀
- 支持带前缀 ID 与裸数字 ID 的安全匹配
- `UserId` 为空时，仅通过双方唯一的玩家名关联
- 不同平台数字部分相同时保持独立
- 候选身份不唯一时不进行推测合并
- 跳过无法确认身份的空 ID 记录
- 保留玩家等级、游玩时长、连接次数及公会信息

## 验证

- Agent 全量测试：100/100 通过
- TypeScript 类型检查通过