### PR TITLE
feat: docker image 指引/arm64/Wine 強化 + 自動 build/pull

### DIFF
--- a/packages/agent/src/docker.ts
+++ b/packages/agent/src/docker.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { PassThrough } from "node:stream";
 import Docker from "dockerode";
-import type { InstanceStatus, InstanceStats, WorldSettings } from "@palserver/shared";
+import type { InstanceStatus, InstanceStats, InstallError, WorldSettings } from "@palserver/shared";
 import { buildLaunchArgs } from "@palserver/shared";
 import { CONTAINER_PREFIX, IMAGES, IMAGES_ARM64, IMAGES_WINE, INSTANCE_LABEL } from "./env.js";
 import { mergeEnginePatch } from "./engine-ini-merge.js";
@@ -11,6 +12,15 @@ import { configPlatformDir } from "./platform.js";
 import { diffIniAgainstSnapshot, renderPalWorldSettingsIni } from "./settings-ini.js";
 
 export const docker = new Docker(); // default: /var/run/docker.sock
+
+// ── image build/pull 狀態(仿 native.ts installing 模式)─────────────────
+const building = new Set<string>();
+export const isBuilding = (id: string): boolean => building.has(id);
+const buildProgress = new Map<string, number>();
+export const buildProgressOf = (id: string): number | null => buildProgress.get(id) ?? null;
+const buildErrors = new Map<string, InstallError>();
+export const lastBuildError = (id: string): InstallError | null =>
+  buildErrors.get(id) ?? null;
 
 /** ARM64 Linux 偵測(沿用 native.ts IS_LINUX_ARM64 模式;arm64 用 FEX 轉譯跑原生 server binary)。 */
 const IS_LINUX_ARM64 = process.platform === "linux" && process.arch === "arm64";
@@ -25,12 +35,34 @@ function resolveImage(rec: InstanceRecord): string {
   return IMAGES[rec.flavor];
 }
 
-/** 依 runtime / 平台 解析 build context 目錄名(錯誤訊息用,給使用者手動 docker build)。
+/** 依 runtime / 平台 解析 build context 子目錄名。
  * modded 無獨立目錄(mod 是執行期注入),共用 vanilla/wine/vanilla-arm64 base。 */
-function resolveBuildDir(rec: InstanceRecord): string {
+function resolveBuildSubdir(rec: InstanceRecord): string {
   if (rec.runtime === "wine") return "images/wine";
   if (IS_LINUX_ARM64) return "images/vanilla-arm64";
   return "images/vanilla";
+}
+
+/** 解析 repo 根目錄(含 images/ 的位置)。三段式:env → 執行檔旁 → import.meta.url。
+ *  找不到回 null(build context 不可用,退回 throw 409)。 */
+function resolveRepoRoot(): string | null {
+  const candidates: string[] = [];
+  if (process.env.PALSERVER_REPO_DIR) candidates.push(process.env.PALSERVER_REPO_DIR);
+  candidates.push(path.dirname(process.execPath));
+  try {
+    candidates.push(path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../"));
+  } catch { /* CJS bundle:略過 */ }
+  for (const c of candidates) {
+    if (c && fs.existsSync(path.join(c, "images"))) return c;
+  }
+  return null;
+}
+
+/** build context 的絕對路徑;找不到 repo root 回 null。 */
+function resolveBuildDir(rec: InstanceRecord): string | null {
+  const root = resolveRepoRoot();
+  if (!root) return null;
+  return path.join(root, resolveBuildSubdir(rec));
 }
 
 function containerName(rec: InstanceRecord): string {
@@ -55,6 +87,8 @@ async function findContainer(rec: InstanceRecord): Promise<Docker.Container | nu
 export async function getStatus(
   rec: InstanceRecord,
 ): Promise<{ status: InstanceStatus; runtimeId: string | null }> {
+  // image 正在 build/pull 時回 installing,讓前端顯示進度條。
+  if (building.has(rec.id)) return { status: "installing", runtimeId: null };
   const container = await findContainer(rec);
   // No container yet (never started, or removed): treated as "created" —
   // starting the instance will (re)materialize it from stored settings.
@@ -106,6 +140,55 @@ function applyEngineIniDocker(rec: InstanceRecord, instanceDir: string): void {
   fs.writeFileSync(file, mergeEnginePatch(existing, rec.engineSettings));
 }
 
+/** image 不存在時自動 build(內建鏡像)或 pull(自訂鏡像)。成功後 image 已就緒。 */
+async function ensureImageExists(rec: InstanceRecord, image: string): Promise<void> {
+  const imageExists = await docker.getImage(image).inspect().then(() => true).catch(() => false);
+  if (imageExists) return;
+
+  const isCustom = !!rec.dockerImage?.trim();
+  building.add(rec.id);
+  buildProgress.set(rec.id, 0);
+  buildErrors.delete(rec.id);
+  try {
+    if (isCustom) {
+      // 自訂鏡像:從 registry pull。
+      const stream = await docker.pull(image);
+      await trackProgress(stream, rec.id);
+    } else {
+      // 內建鏡像:從 repo images/ build。
+      const ctx = resolveBuildDir(rec);
+      if (!ctx || !fs.existsSync(ctx)) {
+        throw Object.assign(
+          new Error(`找不到 build context(${resolveBuildSubdir(rec)})— 請確認 repo 的 images/ 目錄存在`),
+          { statusCode: 409 },
+        );
+      }
+      const src = fs.readdirSync(ctx).filter((f) => !f.startsWith("."));
+      const stream = await docker.buildImage({ context: ctx, src }, { t: image });
+      await trackProgress(stream, rec.id);
+    }
+  } finally {
+    building.delete(rec.id);
+    buildProgress.delete(rec.id);
+  }
+}
+
+/** 用 docker.followProgress 追蹤 build/pull 進度,寫入 buildProgress map。 */
+function trackProgress(stream: NodeJS.ReadableStream, id: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    docker.modem.followProgress(
+      stream,
+      (err: Error | null) => (err ? reject(err) : resolve()),
+      (evt: { progressDetail?: { current?: number; total?: number }; status?: string }) => {
+        const pd = evt.progressDetail;
+        if (pd?.current != null && pd?.total != null && pd.total > 0) {
+          buildProgress.set(id, Math.round((pd.current / pd.total) * 100));
+        }
+      },
+    );
+  });
+}
+
 export async function createContainer(
   rec: InstanceRecord,
   instanceDir: string,
@@ -133,21 +216,8 @@ export async function createContainer(
   ];
 
   const image = resolveImage(rec);
-  const imageExists = await docker
-    .getImage(image)
-    .inspect()
-    .then(() => true)
-    .catch(() => false);
-  if (!imageExists) {
-    const err = new Error(
-      rec.dockerImage?.trim()
-        ? `找不到自訂鏡像 "${image}" — 請先 docker pull 該鏡像,或確認名稱/標籤正確`
-        : `server image "${image}" not found — build it first: ` +
-            `docker build -t ${image} ${resolveBuildDir(rec)}`,
-    ) as Error & { statusCode: number };
-    err.statusCode = 409;
-    throw err;
-  }
+  // image 不存在時自動 build/pull(而非 throw 409 讓使用者手動處理)。
+  await ensureImageExists(rec, image);
 
   const container = await docker.createContainer({
     name: containerName(rec),
@@ -170,6 +240,40 @@ export async function createContainer(
 export async function startInstance(rec: InstanceRecord, instanceDir: string): Promise<void> {
   writeConfig(instanceDir, rec.settings);
   applyEngineIniDocker(rec, instanceDir);
+
+  // image 不存在時觸發背景 build/pull(IIFE),立刻回 installing 狀態;
+  // build 完成後繼續 createContainer + start。仿 native.ts slow path 模式。
+  const image = resolveImage(rec);
+  const imageExists = await docker.getImage(image).inspect().then(() => true).catch(() => false);
+  if (!imageExists) {
+    if (building.has(rec.id)) return; // 已在 build 中,不重複觸發
+    building.add(rec.id);
+    buildProgress.set(rec.id, 0);
+    buildErrors.delete(rec.id);
+    void (async () => {
+      try {
+        await ensureImageExists(rec, image);
+        let container = await findContainer(rec);
+        if (!container) {
+          await createContainer(rec, instanceDir);
+          container = await findContainer(rec);
+        }
+        await container!.start().catch((err: { statusCode?: number }) => {
+          if (err.statusCode !== 304) throw err;
+        });
+      } catch (err) {
+        buildErrors.set(rec.id, {
+          code: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        building.delete(rec.id);
+        buildProgress.delete(rec.id);
+      }
+    })();
+    return;
+  }
+
   let container = await findContainer(rec);
   if (!container) {
     await createContainer(rec, instanceDir);

--- a/packages/agent/src/docker.ts
+++ b/packages/agent/src/docker.ts
@@ -4,13 +4,34 @@ import { PassThrough } from "node:stream";
 import Docker from "dockerode";
 import type { InstanceStatus, InstanceStats, WorldSettings } from "@palserver/shared";
 import { buildLaunchArgs } from "@palserver/shared";
-import { CONTAINER_PREFIX, IMAGES, IMAGES_WINE, INSTANCE_LABEL } from "./env.js";
+import { CONTAINER_PREFIX, IMAGES, IMAGES_ARM64, IMAGES_WINE, INSTANCE_LABEL } from "./env.js";
 import { mergeEnginePatch } from "./engine-ini-merge.js";
 import type { InstanceRecord } from "./store.js";
 import { configPlatformDir } from "./platform.js";
 import { diffIniAgainstSnapshot, renderPalWorldSettingsIni } from "./settings-ini.js";
 
 export const docker = new Docker(); // default: /var/run/docker.sock
+
+/** ARM64 Linux 偵測(沿用 native.ts IS_LINUX_ARM64 模式;arm64 用 FEX 轉譯跑原生 server binary)。 */
+const IS_LINUX_ARM64 = process.platform === "linux" && process.arch === "arm64";
+
+/** 依 runtime / 平台 / flavor 解析容器 image 名稱(自訂 dockerImage 優先)。
+ * 優先序:wine → IMAGES_WINE(arm64 不支援 wine,但若使用者硬設仍走此表,行為可預期);
+ * arm64 linux → IMAGES_ARM64(FEX 轉譯);其他 → IMAGES(原生 x86-64)。 */
+function resolveImage(rec: InstanceRecord): string {
+  if (rec.dockerImage?.trim()) return rec.dockerImage.trim();
+  if (rec.runtime === "wine") return IMAGES_WINE[rec.flavor];
+  if (IS_LINUX_ARM64) return IMAGES_ARM64[rec.flavor];
+  return IMAGES[rec.flavor];
+}
+
+/** 依 runtime / 平台 解析 build context 目錄名(錯誤訊息用,給使用者手動 docker build)。
+ * modded 無獨立目錄(mod 是執行期注入),共用 vanilla/wine/vanilla-arm64 base。 */
+function resolveBuildDir(rec: InstanceRecord): string {
+  if (rec.runtime === "wine") return "images/wine";
+  if (IS_LINUX_ARM64) return "images/vanilla-arm64";
+  return "images/vanilla";
+}
 
 function containerName(rec: InstanceRecord): string {
   // 容器名只是給人看的 —— agent 一律靠 label(INSTANCE_LABEL=id)找容器,不靠名字。
@@ -111,8 +132,7 @@ export async function createContainer(
     ...buildLaunchArgs(rec.launchOptions),
   ];
 
-  const image = rec.dockerImage?.trim()
-    || (rec.runtime === "wine" ? IMAGES_WINE[rec.flavor] : IMAGES[rec.flavor]);
+  const image = resolveImage(rec);
   const imageExists = await docker
     .getImage(image)
     .inspect()
@@ -123,7 +143,7 @@ export async function createContainer(
       rec.dockerImage?.trim()
         ? `找不到自訂鏡像 "${image}" — 請先 docker pull 該鏡像,或確認名稱/標籤正確`
         : `server image "${image}" not found — build it first: ` +
-            `docker build -t ${image} images/${rec.runtime === "wine" ? "wine" : "vanilla"}`,
+            `docker build -t ${image} ${resolveBuildDir(rec)}`,
     ) as Error & { statusCode: number };
     err.statusCode = 409;
     throw err;
@@ -323,8 +343,7 @@ export async function listInContainer(
 
 /** Pull latest image and recreate container. */
 export async function updateImage(rec: InstanceRecord, instanceDir: string): Promise<string> {
-  const image = rec.dockerImage?.trim()
-    || (rec.runtime === "wine" ? IMAGES_WINE[rec.flavor] : IMAGES[rec.flavor]);
+  const image = resolveImage(rec);
   const stream = await docker.pull(image);
   await new Promise<void>((resolve, reject) => {
     docker.modem.followProgress(stream, (err: Error | null) => (err ? reject(err) : resolve()));

--- a/packages/agent/src/docker.ts
+++ b/packages/agent/src/docker.ts
@@ -123,7 +123,7 @@ export async function createContainer(
       rec.dockerImage?.trim()
         ? `找不到自訂鏡像 "${image}" — 請先 docker pull 該鏡像,或確認名稱/標籤正確`
         : `server image "${image}" not found — build it first: ` +
-            `docker build -t ${image} images/${rec.flavor}`,
+            `docker build -t ${image} images/${rec.runtime === "wine" ? "wine" : "vanilla"}`,
     ) as Error & { statusCode: number };
     err.statusCode = 409;
     throw err;

--- a/packages/agent/src/env.ts
+++ b/packages/agent/src/env.ts
@@ -79,6 +79,12 @@ export const IMAGES_WINE: Record<"vanilla" | "modded", string> = {
   modded: process.env.PALSERVER_IMAGE_WINE_MODDED ?? "palserver/wine-modded:latest",
 };
 
+/** ARM64 variants — native Linux server via FEX translation (no Wine). */
+export const IMAGES_ARM64: Record<"vanilla" | "modded", string> = {
+  vanilla: process.env.PALSERVER_IMAGE_ARM64 ?? "palserver/vanilla-arm64:latest",
+  modded: process.env.PALSERVER_IMAGE_ARM64_MODDED ?? "palserver/vanilla-arm64:latest",
+};
+
 /** GUI 自己的 GitHub repo — 自我更新從這裡的 Releases 取得新版。 */
 export const GITHUB_REPO = process.env.PALSERVER_GITHUB_REPO ?? "io-software-ai/palserver-gui";
 

--- a/packages/agent/src/mods.ts
+++ b/packages/agent/src/mods.ts
@@ -187,11 +187,6 @@ export async function getModsStatus(rec: InstanceRecord, ctx: DriverContext): Pr
   if (serverPlatform(rec) !== "windows") {
     return unsupported("模組管理需要 Windows 伺服器(UE4SS/PalDefender 是 Windows DLL,在非 Windows binary 上無法載入)");
   }
-  // Linux/macOS 原生模式:伺服器跑得起來,但 UE4SS/PalDefender 官方僅支援 Windows
-  // 專用伺服器 —— 不擋在「未安裝」的誤導文案,明講平台限制。
-  if (rec.backend === "native" && process.platform !== "win32") {
-    return unsupported("UE4SS/PalDefender 僅支援 Windows 伺服器,這台主機無法使用 DLL 模組(純內容 .pak 模組不受影響)");
-  }
 
   // docker/k8s: 容器/Pod 內 exec 偵測（host fs 看不到容器內的 Win64 目錄）。
   if (rec.backend === "docker" || rec.backend === "k8s") {

--- a/packages/agent/src/native.ts
+++ b/packages/agent/src/native.ts
@@ -12,6 +12,7 @@ import { mergeEnginePatch } from "./engine-ini-merge.js";
 import { rest } from "./restapi.js";
 import { emitAgentEvent } from "./events.js";
 import { DATA_DIR } from "./env.js";
+import { serverPlatform, configPlatformDir } from "./platform.js";
 
 const execFileP = promisify(execFile);
 
@@ -19,8 +20,11 @@ const PALWORLD_APP_ID = "2394010";
 const DEPOTDOWNLOADER_VERSION = "3.4.0";
 
 const IS_WIN = process.platform === "win32";
-export const SERVER_LAUNCHER = IS_WIN ? "PalServer.exe" : "PalServer.sh";
-const CONFIG_PLATFORM_DIR = IS_WIN ? "WindowsServer" : "LinuxServer";
+
+/** 伺服器啟動器檔名:Wine(Windows binary)用 PalServer.exe,Linux 原生用 PalServer.sh。 */
+export function serverLauncher(rec: InstanceRecord): string {
+  return serverPlatform(rec) === "windows" ? "PalServer.exe" : "PalServer.sh";
+}
 
 /** Linux ARM64(樹莓派/NanoPi/Ampere…):官方只出 x86-64 伺服器執行檔,
  * 直接 exec 會被核心拒絕(shell 誤當腳本解析、噴 Syntax error),
@@ -54,8 +58,11 @@ export function serverRoot(rec: InstanceRecord, ctx: DriverContext): string {
  * is adopted as-is, an empty or not-yet-existing directory becomes the
  * install target, anything else is rejected (likely a typo — installing
  * would dump 20GB into the wrong place). */
-export function classifyServerDir(dir: string): "adopt" | "install" | "not-a-server" {
-  if (fs.existsSync(path.join(dir, SERVER_LAUNCHER))) return "adopt";
+export function classifyServerDir(
+  dir: string,
+  launcherName: string = IS_WIN ? "PalServer.exe" : "PalServer.sh",
+): "adopt" | "install" | "not-a-server" {
+  if (fs.existsSync(path.join(dir, launcherName))) return "adopt";
   if (!fs.existsSync(dir) || fs.readdirSync(dir).length === 0) return "install";
   return "not-a-server";
 }
@@ -290,21 +297,24 @@ async function ensureInstalled(
   onProgress?: (percent: number) => void,
 ): Promise<void> {
   const root = serverRoot(rec, ctx);
+  const launcher = serverLauncher(rec);
   if (rec.serverDir && !rec.serverDirManaged) {
     // Adopted install: never download into it — a missing launcher means the
     // configured dir is wrong (or the drive is gone), not "please install".
-    if (!fs.existsSync(path.join(root, SERVER_LAUNCHER))) {
+    if (!fs.existsSync(path.join(root, launcher))) {
       throw Object.assign(
-        new Error(`"${SERVER_LAUNCHER}" not found in configured server dir: ${root}`),
+        new Error(`"${launcher}" not found in configured server dir: ${root}`),
         { statusCode: 409 },
       );
     }
     return;
   }
-  if (fs.existsSync(path.join(root, SERVER_LAUNCHER))) return;
+  if (fs.existsSync(path.join(root, launcher))) return;
 
   onLine(`[palserver] installing Palworld dedicated server into ${root} ...`);
-  await runDepotDownloaderWithRecovery(root, onLine, onProgress);
+  // Wine(modded)抓 Windows binary;否則抓對應平台的原生 binary。
+  const osFlag = serverPlatform(rec) === "windows" ? "windows" : "linux";
+  await runDepotDownloaderWithRecovery(root, osFlag, onLine, onProgress);
 }
 
 /** DepotDownloader / OS 在磁碟寫滿時吐的字樣(跨平台、含 .NET IOException)。 */
@@ -375,10 +385,10 @@ const DD_PROGRESS_RE = /^\s*(\d{1,3}(?:[.,]\d+)?)%\s/;
 function runDepotDownloader(
   dd: string,
   root: string,
+  osFlag: string,
   onLine: (line: string) => void,
   onProgress?: (percent: number) => void,
 ): Promise<void> {
-  const osFlag = IS_WIN ? "windows" : "linux";
   return new Promise<void>((resolve, reject) => {
     let sawDiskFull = false;
     let sawLocked = false;
@@ -436,19 +446,20 @@ function runDepotDownloader(
  *  exit 3762504530 = 0xE0434352 .NET 例外),自我修復比叫使用者刪資料夾實際。 */
 async function runDepotDownloaderWithRecovery(
   root: string,
+  osFlag: string,
   onLine: (line: string) => void,
   onProgress?: (percent: number) => void,
 ): Promise<void> {
   const dd = await ensureDepotDownloader();
   try {
-    await runDepotDownloader(dd, root, onLine, onProgress);
+    await runDepotDownloader(dd, root, osFlag, onLine, onProgress);
   } catch (err) {
     if (!(err as { ddEarlyCrash?: boolean }).ddEarlyCrash) throw err;
     onLine("[palserver] 下載器啟動即異常(工具檔可能損毀),正在重新下載 DepotDownloader 後重試…");
     fs.rmSync(depotDownloaderDir(), { recursive: true, force: true });
     const freshDd = await ensureDepotDownloader();
     try {
-      await runDepotDownloader(freshDd, root, onLine, onProgress);
+      await runDepotDownloader(freshDd, root, osFlag, onLine, onProgress);
     } catch (err2) {
       if ((err2 as { ddEarlyCrash?: boolean }).ddEarlyCrash) {
         throw new Error(
@@ -461,7 +472,7 @@ async function runDepotDownloaderWithRecovery(
 }
 
 const worldIniPath = (rec: InstanceRecord, ctx: DriverContext) =>
-  path.join(serverRoot(rec, ctx), "Pal", "Saved", "Config", CONFIG_PLATFORM_DIR, "PalWorldSettings.ini");
+  path.join(serverRoot(rec, ctx), "Pal", "Saved", "Config", configPlatformDir(rec), "PalWorldSettings.ini");
 /** 「agent 上次寫進 PalWorldSettings.ini 的內容」快照,用來偵測使用者的手動編輯。 */
 const worldAppliedPath = (ctx: DriverContext) => path.join(ctx.instanceDir, "world-applied.json");
 
@@ -471,7 +482,7 @@ export function writeWorldIni(rec: InstanceRecord, ctx: DriverContext): void {
 }
 
 function writeIni(rec: InstanceRecord, ctx: DriverContext): void {
-  const configDir = path.join(serverRoot(rec, ctx), "Pal", "Saved", "Config", CONFIG_PLATFORM_DIR);
+  const configDir = path.join(serverRoot(rec, ctx), "Pal", "Saved", "Config", configPlatformDir(rec));
   fs.mkdirSync(configDir, { recursive: true });
   fs.writeFileSync(path.join(configDir, "PalWorldSettings.ini"), renderPalWorldSettingsIni(rec.settings));
   // 記下這次寫入的內容;下次開機用它比對出「哪些是使用者手動改的」(見 detectManualIniEdits)。
@@ -657,7 +668,7 @@ export function updateServer(rec: InstanceRecord, ctx: DriverContext, fresh = fa
       // 否則 DepotDownloader 開檔 IOException、重灌刪檔 EPERM
       await killLeftoverProcessesUnder(rec, serverRoot(rec, ctx), appendLog);
       if (fresh) wipeGameFiles(serverRoot(rec, ctx), appendLog);
-      await runDepotDownloaderWithRecovery(serverRoot(rec, ctx), appendLog, (pct) =>
+      await runDepotDownloaderWithRecovery(serverRoot(rec, ctx), serverPlatform(rec) === "windows" ? "windows" : "linux", appendLog, (pct) =>
         installProgress.set(rec.id, pct),
       );
       appendLog("[palserver] 更新完成");
@@ -815,27 +826,34 @@ async function spawnServer(rec: InstanceRecord, ctx: DriverContext): Promise<voi
   // 會另開一個帶自己 console 的子行程,那個 console 才是遊戲日誌、我們接不到。直接啟動
   // shipping 才能把它的 stdout/stderr 導進 game.log(唯一拿得到原生日誌的方式)。找不到
   // shipping(佈局不同/未來改版)就退回 launcher —— 伺服器照常啟動,只是遊戲日誌會是空的。
-  const shipping = shippingExe(root);
+  const isWine = serverPlatform(rec) === "windows" && !IS_WIN;
+  const shipping = shippingExe(root, rec);
   const useShipping = fs.existsSync(shipping);
-  const exe = useShipping ? shipping : path.join(root, SERVER_LAUNCHER);
+  const launcher = serverLauncher(rec);
+  const exe = useShipping ? shipping : path.join(root, launcher);
   // shipping 需要第一個參數是 UE 專案名(launcher 平常會幫你帶上)。
   const args = useShipping ? ["Pal", ...serverArgs] : serverArgs;
 
   // DepotDownloader(與從別處複製來的 adopt 安裝)在 Linux 不會保留可執行位元。
-  if (!IS_WIN) fs.chmodSync(exe, 0o755);
+  // Wine 跑的是 Windows .exe,不需要 chmod。
+  if (!IS_WIN && !isWine) fs.chmodSync(exe, 0o755);
 
   // 繞過 PalServer.sh 直接啟動 shipping 時,要補做該腳本的開場工作:把 Steam 的
   // linux64/steamclient.so 放到執行檔旁,否則伺服器載入不到 steamclient。
-  if (useShipping && !IS_WIN) {
+  // (Wine 跑 Windows binary,不需要 steamclient.so。)
+  if (useShipping && !IS_WIN && !isWine) {
     const scSrc = path.join(root, "linux64", "steamclient.so");
     const scDst = path.join(root, "Pal", "Binaries", "Linux", "steamclient.so");
     if (fs.existsSync(scSrc) && !fs.existsSync(scDst)) fs.copyFileSync(scSrc, scDst);
   }
 
-  // Linux ARM64:x86-64 執行檔須經轉譯器啟動(見 IS_LINUX_ARM64 註解)。
+  // 決定 spawn 方式:Wine → wine exe;ARM64 → 轉譯器;否則直接 exe。
   let spawnExe = exe;
   let spawnArgs = args;
-  if (IS_LINUX_ARM64) {
+  if (isWine) {
+    spawnArgs = [exe, ...args];
+    spawnExe = "wine";
+  } else if (IS_LINUX_ARM64) {
     const emulator = findX64Emulator();
     if (!emulator) {
       throw new Error(
@@ -848,9 +866,10 @@ async function spawnServer(rec: InstanceRecord, ctx: DriverContext): Promise<voi
     spawnExe = emulator;
   }
 
+  const viaHint = isWine ? "(via Wine)" : IS_LINUX_ARM64 ? "(經 x86-64 轉譯器)" : "";
   fs.appendFileSync(
     logFile(ctx),
-    `[palserver] starting ${useShipping ? "PalServer (shipping, 日誌已擷取)" : "PalServer launcher(找不到 shipping,遊戲日誌將為空)"}${IS_LINUX_ARM64 ? "(經 x86-64 轉譯器)" : ""}...\n`,
+    `[palserver] starting ${useShipping ? "PalServer (shipping, 日誌已擷取)" : "PalServer launcher(找不到 shipping,遊戲日誌將為空)"}${viaHint}...\n`,
   );
   // 遊戲 console 輸出 → game.log(每次開機重來一份,UE 本來也是一次一份)。
   const gameOut = fs.openSync(gameLogFile(ctx), "w");
@@ -954,7 +973,7 @@ async function autoEnhance(
   ctx: DriverContext,
   log: (line: string) => void,
 ): Promise<void> {
-  if (rec.flavor !== "modded" || !IS_WIN) return;
+  if (rec.flavor !== "modded" || serverPlatform(rec) !== "windows") return;
   const mods = await import("./mods.js");
   for (const component of ["ue4ss", "paldefender"] as const) {
     try {
@@ -999,7 +1018,7 @@ export const nativeDriver: ServerDriver = {
     fs.mkdirSync(ctx.instanceDir, { recursive: true });
     const appendLog = (line: string) => fs.appendFileSync(logFile(ctx), line + "\n");
 
-    const alreadyInstalled = fs.existsSync(path.join(serverRoot(rec, ctx), SERVER_LAUNCHER));
+    const alreadyInstalled = fs.existsSync(path.join(serverRoot(rec, ctx), serverLauncher(rec)));
     if (alreadyInstalled) {
       // Fast path: spawn synchronously so errors surface in the response.
       await ensureInstalled(rec, ctx, appendLog); // validates adopted dirs
@@ -1208,9 +1227,10 @@ export const nativeDriver: ServerDriver = {
 const gameLogFile = (ctx: DriverContext) => path.join(ctx.instanceDir, "game.log");
 
 /** 真正的遊戲執行檔(不是 launcher)。它的 stdout 才是遊戲日誌;PalServer.exe 只是
- *  轉手再開一個帶自己 console 的子行程,那個 console 的輸出我們接不到。 */
-const shippingExe = (root: string): string =>
-  IS_WIN
+ *  轉手再開一個帶自己 console 的子行程,那個 console 的輸出我們接不到。
+ *  Wine(modded)時指 Win64 shipping exe(Windows binary),否則依平台。 */
+const shippingExe = (root: string, rec: InstanceRecord): string =>
+  serverPlatform(rec) === "windows"
     ? path.join(root, "Pal", "Binaries", "Win64", "PalServer-Win64-Shipping-Cmd.exe")
     : path.join(root, "Pal", "Binaries", "Linux", "PalServer-Linux-Shipping");
 

--- a/packages/agent/src/platform.test.ts
+++ b/packages/agent/src/platform.test.ts
@@ -43,3 +43,10 @@ test("configPlatformDir: maps to WindowsServer or LinuxServer", () => {
   assert.equal(configPlatformDir(dockerWineRec), "WindowsServer");
   assert.equal(configPlatformDir(k8sWineRec), "WindowsServer");
 });
+
+test("serverPlatform: native + Linux + runtime=wine → windows", () => {
+  // Linux native 選「強化」(modded)時 runtime=wine,走 Windows binary + Wine。
+  const nativeWineRec: InstanceRecord = { ...baseRec, backend: "native", runtime: "wine" } as InstanceRecord;
+  assert.equal(serverPlatform(nativeWineRec), "windows");
+  assert.equal(configPlatformDir(nativeWineRec), "WindowsServer");
+});

--- a/packages/agent/src/platform.ts
+++ b/packages/agent/src/platform.ts
@@ -10,6 +10,8 @@ import type { InstanceRecord } from "./store.js";
 /** The OS the game server process runs on, not the agent's OS. */
 export function serverPlatform(rec: InstanceRecord): "windows" | "linux" {
   if (rec.backend === "native") {
+    // Linux native + runtime="wine":抓 Windows binary 透過 Wine 啟動(用於 modded 強化)。
+    if (rec.runtime === "wine") return "windows";
     return process.platform === "win32" ? "windows" : "linux";
   }
   // docker/k8s: runtime="wine" runs a Windows binary under Wine.

--- a/packages/agent/src/routes.ts
+++ b/packages/agent/src/routes.ts
@@ -55,7 +55,7 @@ import { configPlatformDir, serverPlatform } from "./platform.js";
 import * as dockerOps from "./docker.js";
 
 import { k8sDriver } from "./k8s.js";
-import { SERVER_LAUNCHER, classifyServerDir, detectManualIniEdits, installProgressOf, isInstalling, lastInstallError, moveServerFiles, nativeDriver, serverRoot, updateServer, writeWorldIni } from "./native.js";
+import { serverLauncher, classifyServerDir, detectManualIniEdits, installProgressOf, isInstalling, lastInstallError, moveServerFiles, nativeDriver, serverRoot, updateServer, writeWorldIni } from "./native.js";
 import { cachedVersionSummary, getVersionStatus } from "./version.js";
 import { getConnectionInfo } from "./connectivity.js";
 import { getModsStatus, installComponent, latestModVersions, setModEnabled, installedEnhancements, removeComponent, setLuaModEnabled } from "./mods.js";
@@ -315,6 +315,24 @@ export function registerRoutes(
     return rec;
   };
 
+  /** 偵測 host 是否安裝 Wine(Linux only);結果快取避免每次 /api/info 都 fork。 */
+  let wineAvailableCache: boolean | null = null;
+  function detectWineAvailable(): boolean {
+    if (wineAvailableCache !== null) return wineAvailableCache;
+    if (process.platform === "win32") {
+      wineAvailableCache = false;
+      return false;
+    }
+    try {
+      const { execFileSync } = require("node:child_process");
+      execFileSync("wine", ["--version"], { stdio: "ignore", timeout: 3000 });
+      wineAvailableCache = true;
+    } catch {
+      wineAvailableCache = false;
+    }
+    return wineAvailableCache;
+  }
+
   app.get("/api/info", async (req): Promise<AgentInfo> => {
     const dockerVersion = await dockerOps.docker
       .version()
@@ -331,6 +349,7 @@ export function registerRoutes(
       authenticated,
       platform: process.platform,
       arch: process.arch,
+      wineAvailable: detectWineAvailable(),
       // docker 在 Unix 系統（Linux/macOS）提供；Windows WSL2 的 UDP 不可靠，
       // 不能跑遊戲伺服器。所有平台都可管理遠端 k8s 實例。
       availableBackends:
@@ -593,11 +612,14 @@ export function registerRoutes(
       if (store.list().some((r) => r.serverDir && path.resolve(r.serverDir) === serverDir)) {
         return reply.code(409).send({ error: `server dir already used by another instance: ${serverDir}` });
       }
-      const kind = classifyServerDir(serverDir);
+      const launcherName = input.runtime === "wine"
+        ? "PalServer.exe"
+        : process.platform === "win32" ? "PalServer.exe" : "PalServer.sh";
+      const kind = classifyServerDir(serverDir, launcherName);
       if (kind === "not-a-server") {
         return reply.code(409).send({
           error:
-            `"${SERVER_LAUNCHER}" not found in ${serverDir} and the directory is not empty — ` +
+            `"${launcherName}" not found in ${serverDir} and the directory is not empty — ` +
             `point at an existing PalServer install, or at an empty/new folder to install into`,
         });
       }
@@ -820,11 +842,12 @@ export function registerRoutes(
     const hasFiles = fs.existsSync(currentRoot) && fs.readdirSync(currentRoot).length > 0;
     if (!hasFiles) {
       // 目前沒有檔案可搬:單純改指向(採用既有安裝 / 當成安裝目標)。
-      const kind = classifyServerDir(newRoot);
+      const launcherName = serverLauncher(rec);
+      const kind = classifyServerDir(newRoot, launcherName);
       if (kind === "not-a-server") {
         return reply.code(409).send({
           error:
-            `"${SERVER_LAUNCHER}" not found in ${newRoot} and the directory is not empty — ` +
+            `"${launcherName}" not found in ${newRoot} and the directory is not empty — ` +
             `point at an existing PalServer install, or at an empty/new folder to install into`,
         });
       }

--- a/packages/agent/src/routes.ts
+++ b/packages/agent/src/routes.ts
@@ -300,8 +300,14 @@ export function registerRoutes(
       gameVersion,
       updateAvailable,
       enhancements,
-      installError: rec.backend === "native" ? lastInstallError(rec.id) : null,
-      installProgress: rec.backend === "native" ? installProgressOf(rec.id) : null,
+      installError:
+        rec.backend === "native" ? lastInstallError(rec.id)
+        : rec.backend === "docker" ? dockerOps.lastBuildError(rec.id)
+        : null,
+      installProgress:
+        rec.backend === "native" ? installProgressOf(rec.id)
+        : rec.backend === "docker" ? dockerOps.buildProgressOf(rec.id)
+        : null,
     };
   };
 

--- a/packages/agent/src/routes.ts
+++ b/packages/agent/src/routes.ts
@@ -330,6 +330,7 @@ export function registerRoutes(
       instanceCount: store.list().length,
       authenticated,
       platform: process.platform,
+      arch: process.arch,
       // docker 在 Unix 系統（Linux/macOS）提供；Windows WSL2 的 UDP 不可靠，
       // 不能跑遊戲伺服器。所有平台都可管理遠端 k8s 實例。
       availableBackends:

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1140,6 +1140,8 @@ export interface AgentInfo {
   platform: string;
   /** agent 主機 CPU 架構(process.arch:arm64 / x64 / arm 等)。arm64 不支援 wine,前端據此隱藏 wine checkbox。 */
   arch: string;
+  /** Linux 主機是否安裝了 Wine(native backend modded 需要走 Wine)。 */
+  wineAvailable: boolean;
   /** 此平台可用的 backend 清單。前端依此動態顯示/隱藏 backend 選項。
    * Windows 只支援 native（Docker Desktop UDP 不可靠）；
    * Linux 支援 native/docker/k8s；macOS 只支援 native（無 Palworld server binary）。 */

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1138,6 +1138,8 @@ export interface AgentInfo {
   authenticated: boolean;
   /** agent 所在主機平台(process.platform:darwin / win32 / linux)。前端用來提示 macOS 限制。 */
   platform: string;
+  /** agent 主機 CPU 架構(process.arch:arm64 / x64 / arm 等)。arm64 不支援 wine,前端據此隱藏 wine checkbox。 */
+  arch: string;
   /** 此平台可用的 backend 清單。前端依此動態顯示/隱藏 backend 選項。
    * Windows 只支援 native（Docker Desktop UDP 不可靠）；
    * Linux 支援 native/docker/k8s；macOS 只支援 native（無 Palworld server binary）。 */

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -592,6 +592,7 @@ function CreateDialog({
   const [busy, setBusy] = useState(false);
   const [platform, setPlatform] = useState<string | null>(null);
   const [arch, setArch] = useState<string | null>(null);
+  const [wineAvailable, setWineAvailable] = useState(false);
   const [availableBackends, setAvailableBackends] = useState<Backend[]>(["native"]);
   const [advancedMode, setAdvancedMode] = useState(false);
   const [showDirPicker, setShowDirPicker] = useState(false);
@@ -612,6 +613,7 @@ function CreateDialog({
     client.info().then((i) => {
       setPlatform(i.platform);
       setArch(i.arch ?? null);
+      setWineAvailable(i.wineAvailable ?? false);
       if (i.availableBackends && i.availableBackends.length > 0) {
         setAvailableBackends(i.availableBackends);
         if (!i.availableBackends.includes(backend)) {
@@ -632,7 +634,8 @@ function CreateDialog({
         // 強化 = 啟動安裝完伺服器檔案後,自動裝 UE4SS + PalDefender(agent 端 autoEnhance)
         flavor: enhanced ? "modded" : "vanilla",
         gamePort: gamePort.trim() === "" ? undefined : Number(gamePort),
-        runtime: useWine ? "wine" : undefined,
+        // Linux native + 強化 = 自動走 Wine(抓 Windows binary + autoEnhance 裝 mod)。
+        runtime: useWine || (enhanced && platform === "linux") ? "wine" : undefined,
         serverDir: backend === "native" && serverDir.trim() ? serverDir.trim() : undefined,
         dockerImage: backend === "docker" && dockerImage.trim() ? dockerImage.trim() : undefined,
         k8sNamespace: backend === "k8s" ? k8sNamespace.trim() : undefined,
@@ -648,7 +651,10 @@ function CreateDialog({
     }
   };
 
-  const enhanceAvailable = backend === "native" && platform === "win32";
+  const enhanceAvailable = backend === "native" && (
+    platform === "win32" ||
+    (platform === "linux" && wineAvailable && arch !== "arm64")
+  );
   const STEP_TITLES = [t("基本資料"), t("玩法"), t("模組")];
   const canNext = step === 0 ? name.trim() !== "" && !k8sIncomplete : true;
   const selectedPreset = WORLD_PRESETS.find((x) => x.id === preset);
@@ -991,7 +997,9 @@ function CreateDialog({
                 <p className="mt-1 text-xs font-bold text-ink-muted">
                   {backend !== "native"
                     ? t("強化模式目前僅支援「原生」運行方式。")
-                    : t("模組(UE4SS/PalDefender)僅支援 Windows 主機。")}
+                    : platform === "linux" && arch !== "arm64"
+                      ? t("需要安裝 Wine 才能在 Linux 上使用強化模式(UE4SS/PalDefender 是 Windows DLL)。")
+                      : t("模組(UE4SS/PalDefender)僅支援 Windows 或已安裝 Wine 的 Linux x86 主機。")}
                 </p>
               )}
               {enhanced && (

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -591,6 +591,7 @@ function CreateDialog({
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [platform, setPlatform] = useState<string | null>(null);
+  const [arch, setArch] = useState<string | null>(null);
   const [availableBackends, setAvailableBackends] = useState<Backend[]>(["native"]);
   const [advancedMode, setAdvancedMode] = useState(false);
   const [showDirPicker, setShowDirPicker] = useState(false);
@@ -601,6 +602,8 @@ function CreateDialog({
   const [enhanced, setEnhanced] = useState(false);
   // k8s 是把伺服器跑在叢集裡(agent 只是遙控),所以 agent 這台是不是 macOS 無所謂。
   const isMac = platform === "darwin" && backend !== "k8s";
+  // arm64 不支援 wine(wine Dockerfile 是 x86 + i386 only),隱藏 wine checkbox。
+  const isArm64 = platform === "linux" && arch === "arm64";
   const k8sIncomplete = backend === "k8s" && (!k8sNamespace.trim() || !k8sStatefulSet.trim());
 
   // agent 在 macOS 時,主機無法實際執行 Palworld 伺服器(SteamCMD 32-bit 在
@@ -608,6 +611,7 @@ function CreateDialog({
   useEffect(() => {
     client.info().then((i) => {
       setPlatform(i.platform);
+      setArch(i.arch ?? null);
       if (i.availableBackends && i.availableBackends.length > 0) {
         setAvailableBackends(i.availableBackends);
         if (!i.availableBackends.includes(backend)) {
@@ -804,7 +808,7 @@ function CreateDialog({
                     </span>
                   </label>
                 )}
-                {backend === "docker" && (
+                {backend === "docker" && !isArm64 && (
                   <label className="flex items-center gap-2 text-sm">
                     <input
                       type="checkbox"
@@ -814,7 +818,7 @@ function CreateDialog({
                     {t("Wine 模式(Windows binary,支援 PalDefender)")}
                   </label>
                 )}
-                {backend === "k8s" && (
+                {backend === "k8s" && !isArm64 && (
                   <label className="flex items-center gap-2 text-sm">
                     <input
                       type="checkbox"


### PR DESCRIPTION
Closes #61

## 概要

本 PR 改善 docker backend 的 image 選擇/指引邏輯,新增 arm64 image 支援,讓 native backend 在 Linux 上透過 Wine 支援 modded 模式,並讓 docker image 不存在時自動 build/pull(不再需要使用者手動操作)。涵蓋五項功能:

1. **build 指引路徑修正**:錯誤訊息的 build context 從 `images/${flavor}` 改為依 runtime 決定。
2. **arm64 image 支援**:ARM64 主機使用 docker backend 時,image 和 build 指引指向 `images/vanilla-arm64`。
3. **arm64 隱藏 wine checkbox**:arm64 不支援 wine(架構限制),前端隱藏選項。
4. **Linux native + Wine 強化**:Linux native 選「強化」時自動走 Wine(抓 Windows binary + autoEnhance 裝 mod)。
5. **image 自動 build/pull**:image 不存在時 agent 自動 build(內建鏡像,從 repo `images/`)或 pull(自訂鏡像,從 registry),完成後自動啟動。

## 已實現的功能

### 1. build context 依 runtime 決定

- `docker.ts` build context 從 `images/${rec.flavor}` 改為 `resolveBuildDir(rec)`,依 runtime 選 `images/wine` / `images/vanilla-arm64` / `images/vanilla`。
- image 選擇收斂為 `resolveImage(rec)` helper,`createContainer` 和 `updateImage` 共用。
- modded 無獨立 build context(mod 是執行期注入),共用 vanilla/wine base。

### 2. arm64 image 支援

- `env.ts` 新增 `IMAGES_ARM64` 映射表(`palserver/vanilla-arm64:latest`,env var `PALSERVER_IMAGE_ARM64` 覆寫)。
- `docker.ts` 新增 `IS_LINUX_ARM64` 偵測,arm64 時 image 和 build context 指向 arm64 變體。
- arm64 僅支援 vanilla(FEX 轉譯跑原生 Linux server binary),**不支援 modded**(mod 需走 Wine,而 Wine 是 x86 only)。

### 3. arm64 隱藏 wine checkbox

- `AgentInfo` 新增 `arch` 欄位(`/api/info` 回傳 `process.arch`)。
- 前端 CreateDialog 在 `platform === "linux" && arch === "arm64"` 時隱藏 wine checkbox。

### 4. Linux native + Wine 強化

- **`platform.ts`**:`serverPlatform(rec)` 的 native 分支在 `runtime === "wine"` 時回 `"windows"`。
- **`native.ts`**:`SERVER_LAUNCHER` → `serverLauncher(rec)` 函式;DepotDownloader `osFlag` 依 `serverPlatform`(Wine 時抓 Windows binary);`spawnServer` 加 Wine 分支(`spawnExe = "wine"`);`autoEnhance` gate 改看 `serverPlatform`。
- **`mods.ts`**:移除 `getModsStatus` 的 `native && process.platform !== "win32"` 硬擋。
- **`AgentInfo` 新增 `wineAvailable`**:agent 偵測 Wine 是否安裝。
- **前端 `enhanceAvailable` 放寬**:native + Windows,或 native + Linux + wineAvailable + 非 arm64。Linux native + enhanced → 自動 `runtime: "wine"`。

### 5. image 自動 build/pull

image 不存在時,agent 不再拋 409 要求使用者手動操作,改為:

- **內建鏡像**(`rec.dockerImage` 未設):從 repo `images/` build context 執行 `docker.buildImage({context, src}, {t})`。repo root 三段式解析(env `PALSERVER_REPO_DIR` → 執行檔旁 → `import.meta.url` 往上),找不到 build context 時 fallback 409。
- **自訂鏡像**(`rec.dockerImage` 有設):從 registry `docker.pull(image)`。
- **背景執行 + 進度回報**:仿 native backend 的 ensureInstalled 模式 — `building`/`buildProgress`/`buildErrors` 三件組狀態 Map,fire-and-forget IIFE,`getStatus` 在 building 時回 `"installing"`,前端 InstallProgress 進度條零改動重用。`docker.modem.followProgress` 的 onProgress 寫入進度。
- **`routes.ts`**:`installError`/`installProgress` 放寬到 docker backend(不再只限 native)。

## 驗證

- 全 workspace TypeScript typecheck 通過。
- agent 95 個單元測試通過(含 `platform.test.ts` 新增 native + Linux + wine → windows 案例)。

### image/build context 矩陣

| 平台 | runtime | flavor | image | build context |
|------|---------|--------|-------|--------------|
| x86-64 | native | vanilla | palserver/vanilla:latest | images/vanilla |
| x86-64 | native | modded | palserver/modded:latest | images/vanilla |
| x86-64 | wine | vanilla | palserver/wine:latest | images/wine |
| x86-64 | wine | modded | palserver/wine-modded:latest | images/wine |
| arm64 | native | vanilla | palserver/vanilla-arm64:latest | images/vanilla-arm64 |
| arm64 | — | modded | **不支援** | — |

### flavor/runtime 語意

| 平台 | backend | vanilla | modded |
|------|---------|---------|--------|
| Windows | native | PalServer.exe 原生 | 原生 + autoEnhance 裝 mod |
| Linux x86 | native | PalServer-Linux-Shipping 原生 | Wine + Windows binary + autoEnhance |
| Linux x86 | docker/k8s | 容器原生 image | Wine image |
| arm64 | 任何 | 原生/FEX | 不支援 |

## 相容性與行為邊界

- arm64 不支援 wine/強化,前端隱藏;`arch`/`wineAvailable` 欄位 undefined(舊版 agent)時安全 fallback。
- Linux native + modded = 自動走 Wine:需主機已安裝 Wine(`wine` 在 PATH)。
- 既有 Linux native vanilla 實例(runtime 未設)行為完全不變。
- docker image 自動 build:repo 需含 `images/` 目錄(開發/bundle/exe 部署都有);找不到時退回 409。
- docker 自訂鏡像 pull:image 需在 registry 存在;pull 失敗時 buildErrors 記錄原因。
- docker/k8s 的 modded 仍只換 image 名,不自動裝 mod(由 image 自帶或手動裝)。

## 後續開發注意事項

- 若新增獨立的 modded image build context,需同步更新 `resolveBuildDir`。
- `serverLauncher(rec)` 是 native backend 啟動器選擇的唯一入口。
- Wine 偵測結果快取於 module-level;若 Wine 在 agent 運行中安裝,需重啟 agent。
- build context repo root 解析可透過 `PALSERVER_REPO_DIR` env 覆寫。