### PR TITLE
feat(perf): per-thread CPU 採集 + 正規化 + 三容器 UI 重設計

### DIFF
--- a/packages/agent/src/docker.ts
+++ b/packages/agent/src/docker.ts
@@ -186,18 +186,19 @@ export async function getStats(rec: InstanceRecord): Promise<InstanceStats | nul
   const cpuDelta = stats.cpu_stats.cpu_usage.total_usage - stats.precpu_stats.cpu_usage.total_usage;
   const sysDelta = stats.cpu_stats.system_cpu_usage - stats.precpu_stats.system_cpu_usage;
   const cpuCount = stats.cpu_stats.online_cpus || 1;
-  // per-core:percpu_usage[i] 是容器在核心 i 的累計 jiffies;與 precpu 差分後除以全系統差分。
-  // sysDelta = 全系統 jiffies 差分,每核 delta/sysDelta*cpuCount = 該核佔該核滿載的比例。
+  // per-thread:percpu_usage[i] 是容器在邏輯處理器 i 的累計 jiffies;與 precpu 差分後
+  // 除以全系統差分 = 該執行緒佔全系統的比例(0–100%)。不乘 cpuCount(否則破百)。
   const percpu = stats.cpu_stats.cpu_usage.percpu_usage;
   const prePercpu = stats.precpu_stats.cpu_usage.percpu_usage;
   const perCore: (number | null)[] | null = percpu && prePercpu && sysDelta > 0
     ? percpu.map((v, i) => {
         const delta = v - (prePercpu[i] ?? 0);
-        return delta > 0 ? Math.min((delta / sysDelta) * cpuCount * 100, 100) : 0;
+        return Math.max(0, Math.min((delta / sysDelta) * 100, 100));
       })
     : null;
   return {
-    cpuPercent: sysDelta > 0 ? (cpuDelta / sysDelta) * cpuCount * 100 : 0,
+    // cpuDelta/sysDelta = 容器佔全系統 CPU 比例(0–100%),不乘 cpuCount(否則可破百)。
+    cpuPercent: sysDelta > 0 ? Math.min((cpuDelta / sysDelta) * 100, 100) : 0,
     cpuCores: cpuCount,
     perCore,
     perCoreScope: "container",

--- a/packages/agent/src/docker.ts
+++ b/packages/agent/src/docker.ts
@@ -186,9 +186,21 @@ export async function getStats(rec: InstanceRecord): Promise<InstanceStats | nul
   const cpuDelta = stats.cpu_stats.cpu_usage.total_usage - stats.precpu_stats.cpu_usage.total_usage;
   const sysDelta = stats.cpu_stats.system_cpu_usage - stats.precpu_stats.system_cpu_usage;
   const cpuCount = stats.cpu_stats.online_cpus || 1;
+  // per-core:percpu_usage[i] 是容器在核心 i 的累計 jiffies;與 precpu 差分後除以全系統差分。
+  // sysDelta = 全系統 jiffies 差分,每核 delta/sysDelta*cpuCount = 該核佔該核滿載的比例。
+  const percpu = stats.cpu_stats.cpu_usage.percpu_usage;
+  const prePercpu = stats.precpu_stats.cpu_usage.percpu_usage;
+  const perCore: (number | null)[] | null = percpu && prePercpu && sysDelta > 0
+    ? percpu.map((v, i) => {
+        const delta = v - (prePercpu[i] ?? 0);
+        return delta > 0 ? Math.min((delta / sysDelta) * cpuCount * 100, 100) : 0;
+      })
+    : null;
   return {
     cpuPercent: sysDelta > 0 ? (cpuDelta / sysDelta) * cpuCount * 100 : 0,
     cpuCores: cpuCount,
+    perCore,
+    perCoreScope: "container",
     memoryBytes: stats.memory_stats.usage ?? 0,
     memoryLimitBytes: stats.memory_stats.limit ?? 0,
   };

--- a/packages/agent/src/k8s.ts
+++ b/packages/agent/src/k8s.ts
@@ -264,9 +264,13 @@ export const k8sDriver: ServerDriver = {
         : null;
 
       const previous = usageMicros === null ? undefined : k8sStatsSamples.get(rec.id);
-      const cpuPercent = usageMicros === null || previous?.podName !== podName
+      // computeCpuPercent 回單核基準(可破百);正規化為佔總算力 0–100%。
+      const rawPercent = usageMicros === null || previous?.podName !== podName
         ? null
         : computeCpuPercent(previous, usageMicros, now);
+      const cpuPercent = rawPercent != null && cpuCores > 0
+        ? Math.max(0, Math.min(rawPercent / cpuCores, 100))
+        : rawPercent;
 
       // per-core 差分(兩種來源各自算)。
       let perCore: (number | null)[] | null = null;

--- a/packages/agent/src/k8s.ts
+++ b/packages/agent/src/k8s.ts
@@ -253,12 +253,58 @@ export const k8sDriver: ServerDriver = {
       const memoryLimitV1 = await readFirst(rec, ["/sys/fs/cgroup/memory/memory.limit_in_bytes"]);
       const memoryLimitBytes = parseMemoryLimit(memoryMax ?? memoryLimitV1);
 
+      // per-core 優先序:cgroup v1 usage_percpu(容器專屬)→ /proc/stat(host 全核)。
+      const perCpuRaw = await readFirst(rec, ["/sys/fs/cgroup/cpuacct/cpuacct.usage_percpu"]);
+      const perCpuMicros = parseUsagePerCpu(perCpuRaw); // 奈秒陣列
+      const perCpuMicrosNorm = perCpuMicros?.map((ns) => ns / 1000) ?? null; // → 微秒
+      const isContainerScope = perCpuMicrosNorm !== null;
+      // cgroup v2 無 per-core → fallback /proc/stat(host 全核)。
+      const procStat = !isContainerScope
+        ? parseProcStatPerCore(await readFirst(rec, ["/proc/stat"]))
+        : null;
+
       const previous = usageMicros === null ? undefined : k8sStatsSamples.get(rec.id);
       const cpuPercent = usageMicros === null || previous?.podName !== podName
         ? null
         : computeCpuPercent(previous, usageMicros, now);
+
+      // per-core 差分(兩種來源各自算)。
+      let perCore: (number | null)[] | null = null;
+      let perCoreScope: "system" | "container" | undefined = undefined;
+      if (perCpuMicrosNorm !== null) {
+        perCoreScope = "container";
+        const prevPerCore = previous?.perCoreMicros;
+        if (prevPerCore && previous.podName === podName) {
+          const wallMicros = (now - previous.atMs) * 1000;
+          perCore = perCpuMicrosNorm.map((cur, i) => {
+            const p = prevPerCore[i] ?? 0;
+            return wallMicros > 0 && cur >= p ? Math.min(((cur - p) / wallMicros) * 100, 100) : null;
+          });
+        }
+      } else if (procStat !== null) {
+        perCoreScope = "system";
+        const prevProcStat = previous?.procStatPerCore;
+        if (prevProcStat && previous.podName === podName) {
+          perCore = procStat.map((cur, i) => {
+            const p = prevProcStat[i];
+            if (!p) return null;
+            const totalDelta = cur.total - p.total;
+            if (totalDelta <= 0) return null;
+            const idleDelta = cur.idle - p.idle;
+            const idleRatio = Math.max(0, Math.min(idleDelta / totalDelta, 1));
+            return Math.round((1 - idleRatio) * 1000) / 10;
+          });
+        }
+      }
+
       if (usageMicros === null) k8sStatsSamples.delete(rec.id);
-      else k8sStatsSamples.set(rec.id, { podName, usageMicros, atMs: now });
+      else k8sStatsSamples.set(rec.id, {
+        podName,
+        usageMicros,
+        atMs: now,
+        perCoreMicros: perCpuMicrosNorm,
+        procStatPerCore: procStat ?? undefined,
+      });
 
       // uptime：從 /proc/uptime 的第一欄（秒）
       let uptimeSeconds: number | undefined;
@@ -287,6 +333,8 @@ export const k8sDriver: ServerDriver = {
       return {
         cpuPercent,
         cpuCores,
+        perCore,
+        perCoreScope,
         memoryBytes,
         memoryLimitBytes,
         processCount,
@@ -347,7 +395,15 @@ export const k8sDriver: ServerDriver = {
   },
 };
 
-type K8sStatsSample = { podName: string; usageMicros: number; atMs: number };
+type K8sStatsSample = {
+  podName: string;
+  usageMicros: number;
+  atMs: number;
+  /** per-core 歷史:cgroup v1 usage_percpu(微秒)或 null。 */
+  perCoreMicros?: number[] | null;
+  /** per-core 歷史:/proc/stat 每核 {idle, total}(jiffies);cgroup v2 fallback 用。 */
+  procStatPerCore?: Array<{ idle: number; total: number }> | null;
+};
 const k8sStatsSamples = new Map<string, K8sStatsSample>();
 
 async function readFirst(rec: InstanceRecord, paths: string[]): Promise<string | null> {
@@ -412,6 +468,32 @@ export function parseProcStatStartTicks(raw: string): number | null {
   const fields = raw.slice(commEnd + 2).trim().split(/\s+/);
   const startTicks = Number(fields[19]); // field 22; fields start at field 3
   return Number.isFinite(startTicks) && startTicks >= 0 ? startTicks : null;
+}
+
+/** 解析 cgroup v1 cpuacct.usage_percpu:空白分隔的每核奈秒陣列(如 "56000000 48000000 ...")。 */
+export function parseUsagePerCpu(raw: string | null): number[] | null {
+  if (!raw) return null;
+  const parts = raw.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return null;
+  const vals = parts.map(Number);
+  return vals.every((v) => Number.isFinite(v) && v >= 0) ? vals : null;
+}
+
+/** 解析 /proc/stat 的 per-core 行:每行 "cpuN user nice sys idle iowait irq softirq steal ..."。
+ *  回傳每核 {idle, total}(jiffies);total = user+nice+sys+idle+iowait+irq+softirq+steal。 */
+export function parseProcStatPerCore(raw: string | null): Array<{ idle: number; total: number }> | null {
+  if (!raw) return null;
+  const result: Array<{ idle: number; total: number }> = [];
+  for (const line of raw.split("\n")) {
+    const m = /^cpu(\d+)\s+(.*)$/.exec(line.trim());
+    if (!m) continue; // 跳過 aggregate "cpu " 行(無數字)
+    const vals = m[2].trim().split(/\s+/).map(Number);
+    if (vals.length < 4 || vals.some((v) => !Number.isFinite(v))) continue;
+    // [user, nice, sys, idle, iowait, irq, softirq, steal, ...]
+    const [user, nice, sys, idle, iowait = 0, irq = 0, softirq = 0, steal = 0] = vals;
+    result.push({ idle, total: user + nice + sys + idle + iowait + irq + softirq + steal });
+  }
+  return result.length > 0 ? result : null;
 }
 
 export function computeContainerUptimeSeconds(

--- a/packages/agent/src/native-stats.test.ts
+++ b/packages/agent/src/native-stats.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { computeCpuPercent } from "./native.js";
+import { computeCpuPercent, computePerCore } from "./native.js";
 
 // 背景:pidusage 的 cpu 欄位在 Windows 用 os.uptime()(整秒)算間隔,短輪詢誤差極大
 // 且 per-pid 歷史被多個輪詢互踩(實測 3 秒內 78%→36%→0%)。agent 改用 ctime 差分自算。
@@ -36,4 +36,31 @@ test("computeCpuPercent:歷史過舊(>10 分鐘)不拿來差分", () => {
 test("computeCpuPercent:無歷史且無 elapsed → 0(不回 NaN)", () => {
   assert.equal(computeCpuPercent(null, 1234, 1, null), 0);
   assert.equal(computeCpuPercent(null, 1234, 1, 0), 0);
+});
+
+// computePerCore:由 os.cpus() 的 per-core {idle, total} 差分算使用率(0–100)。
+
+test("computePerCore:首筆無歷史 → null(需兩筆才能差分)", () => {
+  assert.equal(computePerCore(undefined, [{ idle: 800, total: 1000 }]), null);
+});
+
+test("computePerCore:半載(idle 減半)→ 50%", () => {
+  // total 差 1000,idle 差 500 → 閒置 50% → 使用率 50%
+  const prev = [{ idle: 800, total: 1000 }];
+  const cur = [{ idle: 1300, total: 2000 }];
+  assert.deepEqual(computePerCore(prev, cur), [50]);
+});
+
+test("computePerCore:多核各自獨立計算", () => {
+  // 核0: idle 差 0/total 差 1000 → 使用率 100%
+  // 核1: idle 差 1000/total 差 1000 → 使用率 0%
+  const prev = [{ idle: 0, total: 1000 }, { idle: 0, total: 1000 }];
+  const cur = [{ idle: 0, total: 2000 }, { idle: 1000, total: 2000 }];
+  assert.deepEqual(computePerCore(prev, cur), [100, 0]);
+});
+
+test("computePerCore:totalDelta ≤ 0(計數器回退)→ null", () => {
+  const prev = [{ idle: 500, total: 1000 }];
+  const cur = [{ idle: 400, total: 900 }]; // total 回退
+  assert.deepEqual(computePerCore(prev, cur), [null]);
 });

--- a/packages/agent/src/native.ts
+++ b/packages/agent/src/native.ts
@@ -923,8 +923,43 @@ interface CpuSample {
   /** 取樣時刻(Date.now() 毫秒) */
   at: number;
   stats: InstanceStats;
+  /** per-core 差分用的 os.cpus() 快照:每核 {idle, total} 累計毫秒。 */
+  osCpus?: Array<{ idle: number; total: number }>;
 }
 const cpuSamples = new Map<string, CpuSample>();
+
+/** 由 os.cpus() 各核 times 計算 per-core 使用率(0–100)。
+ *  total = user+nice+sys+idle+irq(不含 iowait/softirq/steal,足夠算閒置率);
+ *  每核 idle 差 / total 差 = 閒置率 → 100 - 閒置率 = 使用率。
+ *  prev/cur 長度不同(熱插拔,極罕見)→ 只比共同前綴;totalDelta≤0 → null(首筆/計數器回退)。 */
+export function computePerCore(
+  prev: Array<{ idle: number; total: number }> | undefined,
+  cur: Array<{ idle: number; total: number }>,
+): (number | null)[] | null {
+  if (!prev || prev.length === 0 || cur.length === 0) return null;
+  const len = Math.min(prev.length, cur.length);
+  const result: (number | null)[] = [];
+  for (let i = 0; i < len; i++) {
+    const totalDelta = cur[i].total - prev[i].total;
+    const idleDelta = cur[i].idle - prev[i].idle;
+    if (totalDelta <= 0) {
+      result.push(null);
+    } else {
+      const idleRatio = Math.max(0, Math.min(idleDelta / totalDelta, 1));
+      result.push(Math.round((1 - idleRatio) * 1000) / 10);
+    }
+  }
+  return result;
+}
+
+/** 把 os.cpus() 壓縮成 per-core {idle, total}(供差分用)。 */
+function snapshotOsCpus(): Array<{ idle: number; total: number }> {
+  return os.cpus().map((c) => {
+    const t = c.times;
+    const total = t.user + t.nice + t.sys + t.idle + t.irq;
+    return { idle: t.idle, total };
+  });
+}
 
 /** CPU%(單核基準,行程樹加總可破百;export 供單元測試):
  *  有上一筆且 ctime 沒回退(行程沒換)→ Δctime/Δt 毫秒精度差分;
@@ -1159,16 +1194,23 @@ export const nativeDriver: ServerDriver = {
     // 改用 ctime(累計 CPU 毫秒,與取樣間隔無關)配 Date.now() 毫秒精度自算差分。
     const ctimeMs = alive.reduce((sum, u) => sum + u.ctime, 0);
     const at = Date.now();
-    const cpuPercent = computeCpuPercent(prev ?? null, ctimeMs, at, mainElapsed ?? null);
+    const coreCount = os.cpus().length;
+    const osCpus = snapshotOsCpus();
+    // computeCpuPercent 回單核基準(可破百);正規化為佔總算力 0–100%。
+    const raw = computeCpuPercent(prev ?? null, ctimeMs, at, mainElapsed ?? null);
+    const cpuPercent = coreCount > 0 ? Math.max(0, Math.min(raw / coreCount, 100)) : null;
+    const perCore = computePerCore(prev?.osCpus, osCpus);
     const stats = {
       cpuPercent,
-      cpuCores: os.cpus().length,
+      cpuCores: coreCount,
+      perCore,
+      perCoreScope: "system" as const,
       memoryBytes: alive.reduce((sum, u) => sum + u.memory, 0),
       memoryLimitBytes: os.totalmem(),
       processCount: alive.length,
       uptimeSeconds: mainElapsed ? Math.round(mainElapsed / 1000) : undefined,
     } satisfies InstanceStats;
-    cpuSamples.set(ctx.instanceDir, { ctimeMs, at, stats });
+    cpuSamples.set(ctx.instanceDir, { ctimeMs, at, stats, osCpus });
     return stats;
   },
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -197,10 +197,14 @@ export interface InstanceDetail extends InstanceSummary {
 }
 
 export interface InstanceStats {
-  /** null when a backend has not collected two valid samples yet. */
+  /** 佔總算力 0–100%(正規化後,不再可破百)。null = 尚未累積兩筆有效取樣。 */
   cpuPercent: number | null;
   /** 主機/容器可用的邏輯核心數,讓前端判讀 cpuPercent 的滿載基準。 */
   cpuCores: number;
+  /** per-core 使用率(0–100);null = 尚未累積兩筆取樣或 backend 不支援。 */
+  perCore?: (number | null)[] | null;
+  /** per-core 語意:"system"=系統全核(含其他行程);"container"=伺服器專屬。 */
+  perCoreScope?: "system" | "container";
   memoryBytes: number;
   memoryLimitBytes: number;
   /** 伺服器行程樹的行程數(native);docker 省略。 */

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -201,9 +201,9 @@ export interface InstanceStats {
   cpuPercent: number | null;
   /** 主機/容器可用的邏輯核心數,讓前端判讀 cpuPercent 的滿載基準。 */
   cpuCores: number;
-  /** per-core 使用率(0–100);null = 尚未累積兩筆取樣或 backend 不支援。 */
+  /** per-thread 使用率(0–100%),每個邏輯處理器一個值;null = 尚未累積兩筆取樣或 backend 不支援。 */
   perCore?: (number | null)[] | null;
-  /** per-core 語意:"system"=系統全核(含其他行程);"container"=伺服器專屬。 */
+  /** per-thread 語意:"system"=系統全部執行緒(含其他行程);"container"=伺服器專屬執行緒。 */
   perCoreScope?: "system" | "container";
   memoryBytes: number;
   memoryLimitBytes: number;

--- a/packages/web/src/PerformanceTab.tsx
+++ b/packages/web/src/PerformanceTab.tsx
@@ -194,7 +194,7 @@ function ThreadChart({ values, lastVal }: { values: Array<number | null>; lastVa
 
   return (
     <div className="rounded-lg border border-line bg-card-soft p-1.5" title={lastVal == null ? undefined : `${lastVal.toFixed(0)}%`}>
-      <div className="mb-0.5 flex items-baseline justify-between">
+      <div className="mb-0.5 flex items-baseline justify-end">
         <span className="text-[8px] font-bold text-ink-muted">{lastVal == null ? "—" : `${lastVal.toFixed(0)}%`}</span>
       </div>
       <svg viewBox={`0 0 ${W} ${H}`} className="h-12 w-full" preserveAspectRatio="none">
@@ -224,11 +224,13 @@ function Stat({
 }) {
   return (
     <div className={`${card} flex flex-col gap-1`}>
-      <span className="inline-flex items-center gap-1.5 text-xs font-bold text-ink-muted">
-        {icon}
-        {label}
-      </span>
-      <span className="text-2xl font-extrabold">{value}</span>
+      <div className="flex items-center justify-between">
+        <span className="inline-flex items-center gap-1.5 text-xs font-bold text-ink-muted">
+          {icon}
+          {label}
+        </span>
+        <span className="text-2xl font-extrabold">{value}</span>
+      </div>
       {sub && <span className="text-xs text-ink-muted">{sub}</span>}
     </div>
   );

--- a/packages/web/src/PerformanceTab.tsx
+++ b/packages/web/src/PerformanceTab.tsx
@@ -97,37 +97,22 @@ export function PerformanceTab({
 
   return (
     <div className="flex flex-col gap-4">
-      {/* CPU 概要(總用量 + per-thread 框框,每個執行緒各自帶折線圖+Y 軸) */}
-      <CpuOverview
-        cpuPercent={cpuPercent}
-        perCore={perCore}
-        perCoreScope={perCoreScope}
-        history={history}
-      />
-
-      {/* 概要數字磚 */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <Stat
-          icon={<FiHardDrive className="size-4" />}
-          label={t("記憶體")}
-          value={stats ? fmtBytes(stats.memoryBytes) : "—"}
-          sub={stats && hasFiniteLimit(memoryLimit) ? `／ ${fmtBytes(memoryLimit)}` : undefined}
-        />
-        <Stat
-          icon={<FiZap className="size-4" />}
-          label={t("伺服器 FPS")}
-          value={metrics ? String(metrics.serverfps) : "—"}
-          sub={metrics ? t("影格 {ms} ms", { ms: metrics.serverframetime.toFixed(1) }) : t("需啟用 REST API")}
-        />
-        <Stat
-          icon={<FiClock className="size-4" />}
-          label={t("運行時間")}
-          value={stats?.uptimeSeconds != null ? fmtDuration(stats.uptimeSeconds) : "—"}
-          sub={stats?.processCount != null ? t("{n} 個行程", { n: stats.processCount }) : undefined}
-        />
+      {/* ① 純數字容器 — 所有當前數值快照 */}
+      <div className={`${card} flex flex-col gap-3`}>
+        <h3 className="inline-flex items-center gap-2 text-sm font-extrabold">
+          <FiActivity className="size-4 text-pal" /> {t("即時數值")}
+          {perCoreScope && <span className="text-xs font-normal text-ink-muted">· {perCoreScope === "system" ? t("系統全執行緒") : t("伺服器專屬")}</span>}
+        </h3>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          <Stat icon={<FiCpu className="size-4" />} label={t("CPU")} value={cpuPercent == null ? "—" : `${cpuPercent.toFixed(0)}%`} sub={t("佔總算力")} />
+          <Stat icon={<FiHardDrive className="size-4" />} label={t("記憶體")} value={stats ? fmtBytes(stats.memoryBytes) : "—"} sub={stats && hasFiniteLimit(memoryLimit) ? `／ ${fmtBytes(memoryLimit)}` : undefined} />
+          <Stat icon={<FiZap className="size-4" />} label={t("伺服器 FPS")} value={metrics ? String(metrics.serverfps) : "—"} sub={metrics ? t("影格 {ms} ms", { ms: metrics.serverframetime.toFixed(1) }) : t("需啟用 REST API")} />
+          <Stat icon={<FiClock className="size-4" />} label={t("運行時間")} value={stats?.uptimeSeconds != null ? fmtDuration(stats.uptimeSeconds) : "—"} sub={stats?.processCount != null ? t("{n} 個行程", { n: stats.processCount }) : undefined} />
+          {metrics && <Stat icon={<FiLayers className="size-4" />} label={t("伺服器運行")} value={fmtDuration(metrics.uptime)} />}
+        </div>
       </div>
 
-      {/* 詳細用量條 */}
+      {/* ② 資源用量容器 — Meter 進度條 */}
       <div className={`${card} flex flex-col gap-4`}>
         <h3 className="inline-flex items-center gap-2 text-sm font-extrabold">
           <FiActivity className="size-4 text-pal" /> {t("資源用量")}
@@ -150,114 +135,49 @@ export function PerformanceTab({
         )}
       </div>
 
-      {/* 走勢圖 */}
+      {/* ③ 即時走勢容器 — 折線圖 + per-thread 框框 */}
       <div className={`${card} flex flex-col gap-4`}>
         <h3 className="inline-flex items-center gap-2 text-sm font-extrabold">
           <FiActivity className="size-4 text-pal" /> {t("即時走勢")}
           <span className="text-xs font-normal text-ink-muted">{t("(最近約 5 分鐘)")}</span>
         </h3>
         <div className="grid gap-4 sm:grid-cols-2">
-          <Trend
-            title={t("CPU 佔總算力")}
-            unit="%"
-            color="#F4A64D"
-            values={history.map((h) => h.cpu)}
-            max={100}
-          />
-          <Trend
-            title={t("記憶體使用率")}
-            unit="%"
-            color="#7BB0E8"
-            values={history.map((h) => (h.memPct == null ? null : h.memPct * 100))}
-            max={100}
-          />
+          <Trend title={t("CPU 佔總算力")} unit="%" color="#F4A64D" values={history.map((h) => h.cpu)} max={100} />
+          <Trend title={t("記憶體使用率")} unit="%" color="#7BB0E8" values={history.map((h) => (h.memPct == null ? null : h.memPct * 100))} max={100} />
           {metrics && (
-            <Trend
-              title={t("伺服器 FPS")}
-              unit=""
-              color="#8FCf8F"
-              values={history.map((h) => h.fps)}
-              max={Math.max(60, ...history.flatMap((h) => (h.fps == null ? [] : [h.fps])))}
-            />
+            <Trend title={t("伺服器 FPS")} unit="" color="#8FCf8F" values={history.map((h) => h.fps)} max={Math.max(60, ...history.flatMap((h) => (h.fps == null ? [] : [h.fps])))} />
           )}
         </div>
+        {/* per-thread 框框:每個邏輯處理器一格,視覺同 Trend(area fill + polyline),框框數量即執行緒數 */}
+        {perCore != null && perCore.length > 0 && (
+          <div className="border-t border-line pt-3">
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-xs font-bold text-ink-muted">{t("各執行緒")}</span>
+              <span className="text-xs text-ink-muted">{perCore.length}</span>
+            </div>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+              {perCore.map((_, threadIdx) => {
+                const threadValues = history.map((h) => h.perCore?.[threadIdx] ?? null);
+                const lastVal = perCore[threadIdx];
+                return <ThreadChart key={threadIdx} values={threadValues} lastVal={lastVal} />;
+              })}
+            </div>
+          </div>
+        )}
         {history.length < 2 && <p className="text-xs text-ink-muted">{t("收集資料中,稍待幾秒走勢就會出現。")}</p>}
       </div>
-
-      {metrics && (
-        <div className={`${card} flex flex-col gap-3`}>
-          <h3 className="inline-flex items-center gap-2 text-sm font-extrabold">
-            <FiLayers className="size-4 text-pal" /> {t("伺服器效能")}
-          </h3>
-          <dl className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm sm:grid-cols-3">
-            <Row k={t("伺服器 FPS")} v={String(metrics.serverfps)} />
-            <Row k={t("影格時間")} v={`${metrics.serverframetime.toFixed(1)} ms`} />
-            <Row k={t("伺服器運行")} v={fmtDuration(metrics.uptime)} />
-          </dl>
-          <p className="text-xs text-ink-muted">
-            {t("伺服器 FPS 越接近設定的目標越流暢;明顯偏低代表 CPU 吃緊,可到「引擎微調」分頁調整。")}
-          </p>
-        </div>
-      )}
     </div>
   );
 }
 
-/** CPU 概要圖卡:總用量數字 + per-thread 框框(純折線圖+Y 軸,不標任何文字)。 */
-function CpuOverview({
-  cpuPercent,
-  perCore,
-  perCoreScope,
-  history,
-}: {
-  cpuPercent: number | null;
-  perCore: (number | null)[] | null;
-  perCoreScope: "system" | "container" | null;
-  history: Sample[];
-}) {
-  const scopeLabel = perCoreScope === "system" ? t("系統全執行緒") : perCoreScope === "container" ? t("伺服器專屬") : null;
-  const hasPerCore = perCore != null && perCore.length > 0;
-
-  return (
-    <div className={`${card} flex flex-col gap-3`}>
-      <div className="flex items-center justify-between">
-        <div className="flex items-baseline gap-2">
-          <span className="inline-flex items-center gap-1.5 text-xs font-bold text-ink-muted">
-            <FiCpu className="size-4" /> CPU
-          </span>
-          <span className="text-2xl font-extrabold">{cpuPercent == null ? "—" : `${cpuPercent.toFixed(0)}%`}</span>
-          <span className="text-xs text-ink-muted">{t("佔總算力")}</span>
-        </div>
-        {scopeLabel && <span className="text-xs text-ink-muted">{scopeLabel}</span>}
-      </div>
-      {/* per-thread 框框:每個邏輯處理器一格,純折線圖+Y 軸,框框數量即執行緒數 */}
-      {hasPerCore ? (
-        <div className="grid grid-cols-3 gap-1.5 sm:grid-cols-4 lg:grid-cols-6">
-          {perCore!.map((_, threadIdx) => {
-            const threadValues = history.map((h) => h.perCore?.[threadIdx] ?? null);
-            const lastVal = perCore![threadIdx];
-            return <ThreadChart key={threadIdx} values={threadValues} lastVal={lastVal} />;
-          })}
-        </div>
-      ) : (
-        <p className="text-xs text-ink-muted">{t("per-thread 資料累積中,稍待幾秒即出現。")}</p>
-      )}
-    </div>
-  );
-}
-
-/** 單一執行緒框框:純折線圖 + Y 軸(0–100%),不標任何文字標籤。 */
+/** 單一執行緒框框:折線圖 + area fill,視覺對齊 Trend;不標文字(hover title 顯示數值)。 */
 function ThreadChart({ values, lastVal }: { values: Array<number | null>; lastVal: number | null }) {
-  const W = 100;
-  const H = 44;
-  const padTop = 2;
-  const padBottom = 2;
-  const plotH = H - padTop - padBottom;
-  const yTicks = [0, 50, 100];
+  const W = 120;
+  const H = 48;
   const pts = values.map((v, i) => {
     if (v == null || !Number.isFinite(v)) return null;
     const x = values.length > 1 ? (i / (values.length - 1)) * W : 0;
-    const y = padTop + plotH - Math.max(0, Math.min(v / 100, 1)) * plotH;
+    const y = H - Math.max(0, Math.min(v / 100, 1)) * (H - 4) - 2;
     return `${x.toFixed(1)},${y.toFixed(1)}`;
   });
   const segments: string[][] = [];
@@ -267,21 +187,21 @@ function ThreadChart({ values, lastVal }: { values: Array<number | null>; lastVa
     else seg.push(p);
   }
   if (seg.length) segments.push(seg);
-  // 高載(>80%)用橘色警示,其餘藍色;hover title 顯示數值。
-  const stroke = lastVal == null ? "#666" : lastVal > 80 ? "#F4A64D" : "#7BB0E8";
+  const area = values.length > 1 && pts.every((p) => p != null) ? `0,${H} ${pts.join(" ")} ${W},${H}` : "";
+  // 高載(>80%)用橘色警示,其餘藍色。
+  const color = lastVal == null ? "#666" : lastVal > 80 ? "#F4A64D" : "#7BB0E8";
 
   return (
-    <div className="flex gap-0.5 rounded-md border border-line bg-card-soft p-1" title={lastVal == null ? undefined : `${lastVal.toFixed(0)}%`}>
-      {/* Y 軸標示(0/50/100) */}
-      <div className="flex shrink-0 flex-col justify-between py-0.5 text-[7px] leading-none text-ink-muted">
-        {yTicks.map((tick) => <span key={tick}>{tick}</span>)}
-      </div>
-      {/* 折線圖 */}
-      <svg viewBox={`0 0 ${W} ${H}`} className="h-11 flex-1 overflow-visible" preserveAspectRatio="none">
-        <line x1="0" y1={padTop + plotH * 0.5} x2={W} y2={padTop + plotH * 0.5} stroke="currentColor" strokeWidth="0.5" className="text-line" opacity="0.3" />
-        {segments.map((s, i) => s.length > 1 && (
-          <polyline key={i} points={s.join(" ")} fill="none" stroke={stroke} strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
-        ))}
+    <div className="rounded-lg border border-line bg-card-soft p-1.5" title={lastVal == null ? undefined : `${lastVal.toFixed(0)}%`}>
+      <svg viewBox={`0 0 ${W} ${H}`} className="h-12 w-full" preserveAspectRatio="none">
+        {segments.some((s) => s.length > 1) && (
+          <>
+            {area && <polygon points={area} fill={color} opacity="0.12" />}
+            {segments.map((s, i) => (
+              <polyline key={i} points={s.join(" ")} fill="none" stroke={color} strokeWidth="2" strokeLinejoin="round" strokeLinecap="round" />
+            ))}
+          </>
+        )}
       </svg>
     </div>
   );

--- a/packages/web/src/PerformanceTab.tsx
+++ b/packages/web/src/PerformanceTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { FiCpu, FiActivity, FiClock, FiLayers, FiZap, FiHardDrive } from "react-icons/fi";
+import { FiCpu, FiActivity, FiClock, FiLayers, FiZap, FiHardDrive, FiChevronDown } from "react-icons/fi";
 import type { InstanceStats, LiveStatus } from "@palserver/shared";
 import type { AgentClient } from "./api";
 import { t, useI18n } from "./i18n";
@@ -9,9 +9,10 @@ import { EmptyState, card } from "./ui";
 const HISTORY = 60;
 
 interface Sample {
-  cpu: number | null; // 佔單核的百分比；null 代表尚未取得有效取樣
-  memPct: number | null; // 記憶體用量佔上限；null 代表沒有有限上限
-  fps: number | null; // 伺服器 FPS(需 REST API)
+  cpu: number | null; // 佔總算力 0–100%(後端正規化後);null 代表尚未取得有效取樣
+  perCore: (number | null)[] | null; // per-core 使用率(0–100);null = backend 不支援或首筆
+  memPct: number | null;
+  fps: number | null;
 }
 
 /**
@@ -62,6 +63,7 @@ export function PerformanceTab({
             ...prev,
             {
               cpu: cpuPercent,
+              perCore: s.perCore ?? null,
               memPct: hasFiniteLimit(s.memoryLimitBytes)
                 ? clampRatio(s.memoryBytes / s.memoryLimitBytes)
                 : null,
@@ -87,21 +89,25 @@ export function PerformanceTab({
 
   const metrics = live?.metrics ?? null;
   const cores = stats && Number.isFinite(stats.cpuCores) && stats.cpuCores > 0 ? stats.cpuCores : 1;
-  const cpuPercent = stats && knownCpuSample(stats.cpuPercent) ? stats.cpuPercent : null;
-  const cpuOfTotal = cpuPercent == null ? null : clampRatio(cpuPercent / (cores * 100)); // 佔總算力
+  const cpuPercent = stats && knownCpuSample(stats.cpuPercent) ? stats.cpuPercent : null; // 佔總算力 0–100%(後端正規化)
+  const perCore = stats?.perCore ?? null;
+  const perCoreScope = stats?.perCoreScope ?? null;
   const memoryLimit = stats?.memoryLimitBytes ?? 0;
   const memoryRatio = stats && hasFiniteLimit(memoryLimit) ? clampRatio(stats.memoryBytes / memoryLimit) : null;
 
   return (
     <div className="flex flex-col gap-4">
+      {/* CPU 概要(總用量 + per-core 框框 + 抽屜展開多核走勢) */}
+      <CpuOverview
+        cpuPercent={cpuPercent}
+        cores={cores}
+        perCore={perCore}
+        perCoreScope={perCoreScope}
+        history={history}
+      />
+
       {/* 概要數字磚 */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <Stat
-          icon={<FiCpu className="size-4" />}
-          label="CPU"
-          value={cpuPercent == null ? "—" : `${cpuPercent.toFixed(0)}%`}
-          sub={cpuOfTotal == null ? undefined : t("共 {cores} 核 · 佔總算力 {pct}%", { cores, pct: (cpuOfTotal * 100).toFixed(0) })}
-        />
         <Stat
           icon={<FiHardDrive className="size-4" />}
           label={t("記憶體")}
@@ -131,8 +137,8 @@ export function PerformanceTab({
           <>
             <Meter
               label={t("CPU（佔總算力）")}
-              text={cpuOfTotal == null ? "—" : `${(cpuOfTotal * 100).toFixed(1)}%`}
-              ratio={cpuOfTotal}
+              text={cpuPercent == null ? "—" : `${cpuPercent.toFixed(1)}%`}
+              ratio={cpuPercent == null ? null : clampRatio(cpuPercent / 100)}
             />
             <Meter
               label={t("記憶體")}
@@ -156,7 +162,7 @@ export function PerformanceTab({
             title={t("CPU 佔總算力")}
             unit="%"
             color="#F4A64D"
-            values={history.map((h) => (h.cpu == null ? null : clampRatio(h.cpu / (cores * 100)) * 100))}
+            values={history.map((h) => h.cpu)}
             max={100}
           />
           <Trend
@@ -194,6 +200,118 @@ export function PerformanceTab({
           </p>
         </div>
       )}
+    </div>
+  );
+}
+
+/** CPU 概要圖卡:總用量數字 + per-core 框框 + 抽屜展開 per-core 摺線圖。 */
+function CpuOverview({
+  cpuPercent,
+  cores,
+  perCore,
+  perCoreScope,
+  history,
+}: {
+  cpuPercent: number | null;
+  cores: number;
+  perCore: (number | null)[] | null;
+  perCoreScope: "system" | "container" | null;
+  history: Sample[];
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const scopeLabel = perCoreScope === "system" ? t("系統全核") : perCoreScope === "container" ? t("伺服器專屬") : null;
+  const hasPerCore = perCore != null && perCore.length > 0;
+
+  return (
+    <div className={`${card} flex flex-col gap-2`}>
+      <div className="flex items-center justify-between">
+        <span className="inline-flex items-center gap-1.5 text-xs font-bold text-ink-muted">
+          <FiCpu className="size-4" /> CPU
+        </span>
+        {scopeLabel && <span className="text-xs text-ink-muted">{scopeLabel}</span>}
+      </div>
+      <div className="flex items-baseline gap-2">
+        <span className="text-2xl font-extrabold">{cpuPercent == null ? "—" : `${cpuPercent.toFixed(0)}%`}</span>
+        <span className="text-xs text-ink-muted">{t("共 {cores} 核 · 佔總算力", { cores })}</span>
+      </div>
+      {/* per-core 框框(像工作管理員):每核一格,填色高度按使用率 */}
+      {hasPerCore && (
+        <div className="flex flex-wrap gap-1">
+          {perCore!.map((usage, i) => {
+            const pct = usage == null ? null : Math.max(0, Math.min(usage, 100));
+            return (
+              <div
+                key={i}
+                className="relative h-8 w-4 overflow-hidden rounded-sm bg-card-soft"
+                title={pct == null ? t("核心 {n}", { n: i }) : t("核心 {n}: {pct}%", { n: i, pct: pct.toFixed(0) })}
+              >
+                {pct != null && (
+                  <div
+                    className="absolute bottom-0 left-0 right-0 rounded-sm bg-pal transition-all"
+                    style={{ height: `${pct}%` }}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+      {/* 抽屜:展開 per-core 摺線圖 */}
+      {hasPerCore && (
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 text-xs font-bold text-ink-muted transition-transform"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((v) => !v)}
+        >
+          <FiChevronDown className={`size-3.5 transition-transform ${expanded ? "rotate-180" : ""}`} />
+          {expanded ? t("收合多核走勢") : t("展開多核走勢")}
+        </button>
+      )}
+      {expanded && hasPerCore && (
+        <div className="flex flex-col gap-2 border-t border-line pt-2">
+          {perCore!.map((_, coreIdx) => {
+            const coreValues = history.map((h) => h.perCore?.[coreIdx] ?? null);
+            const lastVal = coreValues.filter((v): v is number => v != null).at(-1) ?? null;
+            return (
+              <div key={coreIdx} className="flex items-center gap-2">
+                <span className="w-12 shrink-0 text-xs text-ink-muted">{t("核{n}", { n: coreIdx })}</span>
+                <CoreSparkline values={coreValues} lastVal={lastVal} />
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** per-core 迷你摺線圖(每核一條)。 */
+function CoreSparkline({ values, lastVal }: { values: Array<number | null>; lastVal: number | null }) {
+  const W = 200;
+  const H = 24;
+  const known = values.filter((v): v is number => v != null && Number.isFinite(v));
+  const pts = values.map((v, i) => {
+    if (v == null || !Number.isFinite(v)) return null;
+    const x = values.length > 1 ? (i / (values.length - 1)) * W : 0;
+    const y = H - Math.max(0, Math.min(v / 100, 1)) * (H - 2) - 1;
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+  const segments: string[][] = [];
+  let seg: string[] = [];
+  for (const p of pts) {
+    if (p == null) { if (seg.length) segments.push(seg); seg = []; }
+    else seg.push(p);
+  }
+  if (seg.length) segments.push(seg);
+  return (
+    <div className="flex flex-1 items-center gap-2">
+      <svg viewBox={`0 0 ${W} ${H}`} className="h-6 flex-1" preserveAspectRatio="none">
+        {segments.map((s, i) => s.length > 1 && (
+          <polyline key={i} points={s.join(" ")} fill="none" stroke="#F4A64D" strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
+        ))}
+      </svg>
+      <span className="w-10 shrink-0 text-right text-xs font-bold text-pal">{lastVal == null ? "—" : `${lastVal.toFixed(0)}%`}</span>
     </div>
   );
 }

--- a/packages/web/src/PerformanceTab.tsx
+++ b/packages/web/src/PerformanceTab.tsx
@@ -101,14 +101,13 @@ export function PerformanceTab({
       <div className={`${card} flex flex-col gap-3`}>
         <h3 className="inline-flex items-center gap-2 text-sm font-extrabold">
           <FiActivity className="size-4 text-pal" /> {t("即時數值")}
-          {perCoreScope && <span className="text-xs font-normal text-ink-muted">· {perCoreScope === "system" ? t("系統全執行緒") : t("伺服器專屬")}</span>}
         </h3>
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-          <Stat icon={<FiCpu className="size-4" />} label={t("CPU")} value={cpuPercent == null ? "—" : `${cpuPercent.toFixed(0)}%`} sub={t("佔總算力")} />
-          <Stat icon={<FiHardDrive className="size-4" />} label={t("記憶體")} value={stats ? fmtBytes(stats.memoryBytes) : "—"} sub={stats && hasFiniteLimit(memoryLimit) ? `／ ${fmtBytes(memoryLimit)}` : undefined} />
+          <Stat icon={<FiCpu className="size-4" />} label={t("CPU")} value={cpuPercent == null ? "—" : `${cpuPercent.toFixed(0)}%`} />
+          <Stat icon={<FiHardDrive className="size-4" />} label={t("記憶體")} value={stats ? (hasFiniteLimit(memoryLimit) ? `${fmtBytes(stats.memoryBytes)} / ${fmtBytes(memoryLimit)}` : fmtBytes(stats.memoryBytes)) : "—"} />
           <Stat icon={<FiZap className="size-4" />} label={t("伺服器 FPS")} value={metrics ? String(metrics.serverfps) : "—"} sub={metrics ? undefined : t("需啟用 REST API")} />
           {metrics && <Stat icon={<FiActivity className="size-4" />} label={t("影格時間")} value={`${metrics.serverframetime.toFixed(1)} ms`} />}
-          <Stat icon={<FiClock className="size-4" />} label={t("運行時間")} value={stats?.uptimeSeconds != null ? fmtDuration(stats.uptimeSeconds) : "—"} sub={stats?.processCount != null ? t("{n} 個行程", { n: stats.processCount }) : undefined} />
+          <Stat icon={<FiClock className="size-4" />} label={t("運行時間")} value={stats?.uptimeSeconds != null ? fmtDuration(stats.uptimeSeconds) : "—"} />
           {metrics && <Stat icon={<FiLayers className="size-4" />} label={t("伺服器運行")} value={fmtDuration(metrics.uptime)} />}
         </div>
       </div>
@@ -142,21 +141,15 @@ export function PerformanceTab({
           <FiActivity className="size-4 text-pal" /> {t("即時走勢")}
           <span className="text-xs font-normal text-ink-muted">{t("(最近約 5 分鐘)")}</span>
         </h3>
-        <div className="grid gap-4 sm:grid-cols-2">
-          <Trend title={t("CPU 佔總算力")} unit="%" color="#F4A64D" values={history.map((h) => h.cpu)} max={100} />
-          <Trend title={t("記憶體使用率")} unit="%" color="#7BB0E8" values={history.map((h) => (h.memPct == null ? null : h.memPct * 100))} max={100} />
-          {metrics && (
-            <Trend title={t("伺服器 FPS")} unit="" color="#8FCf8F" values={history.map((h) => h.fps)} max={Math.max(60, ...history.flatMap((h) => (h.fps == null ? [] : [h.fps])))} />
-          )}
-        </div>
-        {/* per-thread 框框:每個邏輯處理器一格,視覺同 Trend(area fill + polyline),框框數量即執行緒數 */}
+        {/* CPU Trend 獨立整行,下方接執行緒框框(視覺連貫) */}
+        <Trend title={t("CPU")} unit="%" color="#F4A64D" values={history.map((h) => h.cpu)} max={100} />
         {perCore != null && perCore.length > 0 && (
-          <div className="border-t border-line pt-3">
+          <div>
             <div className="mb-2 flex items-center justify-between">
-              <span className="text-xs font-bold text-ink-muted">{t("CPU% · 各執行緒")}</span>
+              <span className="text-xs font-bold text-ink-muted">{t("執行緒")}</span>
               <span className="text-xs text-ink-muted">{perCore.length}</span>
             </div>
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+            <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 lg:grid-cols-6">
               {perCore.map((_, threadIdx) => {
                 const threadValues = history.map((h) => h.perCore?.[threadIdx] ?? null);
                 const lastVal = perCore[threadIdx];
@@ -165,6 +158,13 @@ export function PerformanceTab({
             </div>
           </div>
         )}
+        {/* 記憶體 + FPS 共享一行 */}
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Trend title={t("記憶體使用率")} unit="%" color="#7BB0E8" values={history.map((h) => (h.memPct == null ? null : h.memPct * 100))} max={100} />
+          {metrics && (
+            <Trend title={t("伺服器 FPS")} unit="" color="#8FCf8F" values={history.map((h) => h.fps)} max={Math.max(60, ...history.flatMap((h) => (h.fps == null ? [] : [h.fps])))} />
+          )}
+        </div>
         {history.length < 2 && <p className="text-xs text-ink-muted">{t("收集資料中,稍待幾秒走勢就會出現。")}</p>}
       </div>
     </div>

--- a/packages/web/src/PerformanceTab.tsx
+++ b/packages/web/src/PerformanceTab.tsx
@@ -224,13 +224,11 @@ function Stat({
 }) {
   return (
     <div className={`${card} flex flex-col gap-1`}>
-      <div className="flex items-center justify-between">
-        <span className="inline-flex items-center gap-1.5 text-xs font-bold text-ink-muted">
-          {icon}
-          {label}
-        </span>
-        <span className="text-2xl font-extrabold">{value}</span>
-      </div>
+      <span className="inline-flex items-center gap-1.5 text-xs font-bold text-ink-muted">
+        {icon}
+        {label}
+      </span>
+      <span className="text-2xl font-extrabold">{value}</span>
       {sub && <span className="text-xs text-ink-muted">{sub}</span>}
     </div>
   );

--- a/packages/web/src/PerformanceTab.tsx
+++ b/packages/web/src/PerformanceTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { FiCpu, FiActivity, FiClock, FiLayers, FiZap, FiHardDrive, FiChevronDown } from "react-icons/fi";
+import { FiCpu, FiActivity, FiClock, FiLayers, FiZap, FiHardDrive } from "react-icons/fi";
 import type { InstanceStats, LiveStatus } from "@palserver/shared";
 import type { AgentClient } from "./api";
 import { t, useI18n } from "./i18n";
@@ -97,7 +97,7 @@ export function PerformanceTab({
 
   return (
     <div className="flex flex-col gap-4">
-      {/* CPU 概要(總用量 + per-core 框框 + 抽屜展開多核走勢) */}
+      {/* CPU 概要(總用量 + per-thread 框框,每個執行緒各自帶折線圖+Y 軸) */}
       <CpuOverview
         cpuPercent={cpuPercent}
         cores={cores}
@@ -204,7 +204,7 @@ export function PerformanceTab({
   );
 }
 
-/** CPU 概要圖卡:總用量數字 + per-core 框框 + 抽屜展開 per-core 摺線圖。 */
+/** CPU 概要圖卡:總用量數字 + per-thread 框框(每個邏輯處理器一格,各自帶折線圖+XY 軸)。 */
 function CpuOverview({
   cpuPercent,
   cores,
@@ -218,83 +218,56 @@ function CpuOverview({
   perCoreScope: "system" | "container" | null;
   history: Sample[];
 }) {
-  const [expanded, setExpanded] = useState(false);
-  const scopeLabel = perCoreScope === "system" ? t("系統全核") : perCoreScope === "container" ? t("伺服器專屬") : null;
+  const scopeLabel = perCoreScope === "system" ? t("系統全執行緒") : perCoreScope === "container" ? t("伺服器專屬") : null;
+  const threadCount = perCore?.length ?? cores;
   const hasPerCore = perCore != null && perCore.length > 0;
 
   return (
-    <div className={`${card} flex flex-col gap-2`}>
+    <div className={`${card} flex flex-col gap-3`}>
       <div className="flex items-center justify-between">
-        <span className="inline-flex items-center gap-1.5 text-xs font-bold text-ink-muted">
-          <FiCpu className="size-4" /> CPU
+        <div className="flex items-baseline gap-2">
+          <span className="inline-flex items-center gap-1.5 text-xs font-bold text-ink-muted">
+            <FiCpu className="size-4" /> CPU
+          </span>
+          <span className="text-2xl font-extrabold">{cpuPercent == null ? "—" : `${cpuPercent.toFixed(0)}%`}</span>
+          <span className="text-xs text-ink-muted">{t("佔總算力")}</span>
+        </div>
+        <span className="text-xs text-ink-muted">
+          {t("{n} 執行緒", { n: threadCount })}
+          {scopeLabel ? ` · ${scopeLabel}` : ""}
         </span>
-        {scopeLabel && <span className="text-xs text-ink-muted">{scopeLabel}</span>}
       </div>
-      <div className="flex items-baseline gap-2">
-        <span className="text-2xl font-extrabold">{cpuPercent == null ? "—" : `${cpuPercent.toFixed(0)}%`}</span>
-        <span className="text-xs text-ink-muted">{t("共 {cores} 核 · 佔總算力", { cores })}</span>
-      </div>
-      {/* per-core 框框(像工作管理員):每核一格,填色高度按使用率 */}
-      {hasPerCore && (
-        <div className="flex flex-wrap gap-1">
-          {perCore!.map((usage, i) => {
-            const pct = usage == null ? null : Math.max(0, Math.min(usage, 100));
+      {/* per-thread 框框:每個邏輯處理器一格,各自帶完整折線圖 + Y 軸(0–100%) */}
+      {hasPerCore ? (
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+          {perCore!.map((_, threadIdx) => {
+            const threadValues = history.map((h) => h.perCore?.[threadIdx] ?? null);
+            const lastVal = perCore![threadIdx];
             return (
-              <div
-                key={i}
-                className="relative h-8 w-4 overflow-hidden rounded-sm bg-card-soft"
-                title={pct == null ? t("核心 {n}", { n: i }) : t("核心 {n}: {pct}%", { n: i, pct: pct.toFixed(0) })}
-              >
-                {pct != null && (
-                  <div
-                    className="absolute bottom-0 left-0 right-0 rounded-sm bg-pal transition-all"
-                    style={{ height: `${pct}%` }}
-                  />
-                )}
-              </div>
+              <ThreadChart key={threadIdx} index={threadIdx} values={threadValues} lastVal={lastVal} />
             );
           })}
         </div>
-      )}
-      {/* 抽屜:展開 per-core 摺線圖 */}
-      {hasPerCore && (
-        <button
-          type="button"
-          className="inline-flex items-center gap-1 text-xs font-bold text-ink-muted transition-transform"
-          aria-expanded={expanded}
-          onClick={() => setExpanded((v) => !v)}
-        >
-          <FiChevronDown className={`size-3.5 transition-transform ${expanded ? "rotate-180" : ""}`} />
-          {expanded ? t("收合多核走勢") : t("展開多核走勢")}
-        </button>
-      )}
-      {expanded && hasPerCore && (
-        <div className="flex flex-col gap-2 border-t border-line pt-2">
-          {perCore!.map((_, coreIdx) => {
-            const coreValues = history.map((h) => h.perCore?.[coreIdx] ?? null);
-            const lastVal = coreValues.filter((v): v is number => v != null).at(-1) ?? null;
-            return (
-              <div key={coreIdx} className="flex items-center gap-2">
-                <span className="w-12 shrink-0 text-xs text-ink-muted">{t("核{n}", { n: coreIdx })}</span>
-                <CoreSparkline values={coreValues} lastVal={lastVal} />
-              </div>
-            );
-          })}
-        </div>
+      ) : (
+        <p className="text-xs text-ink-muted">{t("per-thread 資料累積中,稍待幾秒即出現。")}</p>
       )}
     </div>
   );
 }
 
-/** per-core 迷你摺線圖(每核一條)。 */
-function CoreSparkline({ values, lastVal }: { values: Array<number | null>; lastVal: number | null }) {
-  const W = 200;
-  const H = 24;
-  const known = values.filter((v): v is number => v != null && Number.isFinite(v));
+/** 單一執行緒的框框:標題 + 當前值 + 折線圖(含 Y 軸 0–100% 標示)。 */
+function ThreadChart({ index, values, lastVal }: { index: number; values: Array<number | null>; lastVal: number | null }) {
+  const W = 120;
+  const H = 50;
+  const paddingTop = 4;
+  const paddingBottom = 4;
+  const plotH = H - paddingTop - paddingBottom;
+  // Y 軸:0–100%,固定刻度(0/50/100),讓每個框框比例一致可比較。
+  const yTicks = [0, 50, 100];
   const pts = values.map((v, i) => {
     if (v == null || !Number.isFinite(v)) return null;
     const x = values.length > 1 ? (i / (values.length - 1)) * W : 0;
-    const y = H - Math.max(0, Math.min(v / 100, 1)) * (H - 2) - 1;
+    const y = paddingTop + plotH - Math.max(0, Math.min(v / 100, 1)) * plotH;
     return `${x.toFixed(1)},${y.toFixed(1)}`;
   });
   const segments: string[][] = [];
@@ -304,14 +277,30 @@ function CoreSparkline({ values, lastVal }: { values: Array<number | null>; last
     else seg.push(p);
   }
   if (seg.length) segments.push(seg);
+  const lastDisplay = lastVal == null ? "—" : `${lastVal.toFixed(0)}%`;
+
   return (
-    <div className="flex flex-1 items-center gap-2">
-      <svg viewBox={`0 0 ${W} ${H}`} className="h-6 flex-1" preserveAspectRatio="none">
-        {segments.map((s, i) => s.length > 1 && (
-          <polyline key={i} points={s.join(" ")} fill="none" stroke="#F4A64D" strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
-        ))}
-      </svg>
-      <span className="w-10 shrink-0 text-right text-xs font-bold text-pal">{lastVal == null ? "—" : `${lastVal.toFixed(0)}%`}</span>
+    <div className="rounded-lg border border-line bg-card-soft p-2">
+      <div className="mb-1 flex items-baseline justify-between">
+        <span className="text-xs font-bold text-ink-muted">{t("執行緒 {n}", { n: index })}</span>
+        <span className="text-sm font-extrabold text-pal">{lastDisplay}</span>
+      </div>
+      <div className="flex gap-1">
+        {/* Y 軸標示 */}
+        <div className="flex shrink-0 flex-col justify-between py-0.5 text-[8px] leading-none text-ink-muted">
+          {yTicks.map((tick) => (
+            <span key={tick}>{tick}</span>
+          ))}
+        </div>
+        {/* 折線圖本體 */}
+        <svg viewBox={`0 0 ${W} ${H}`} className="h-12 flex-1 overflow-visible" preserveAspectRatio="none">
+          {/* Y=50% 參考線 */}
+          <line x1="0" y1={paddingTop + plotH * 0.5} x2={W} y2={paddingTop + plotH * 0.5} stroke="currentColor" strokeWidth="0.5" className="text-line" opacity="0.4" />
+          {segments.map((s, i) => s.length > 1 && (
+            <polyline key={i} points={s.join(" ")} fill="none" stroke="#F4A64D" strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
+          ))}
+        </svg>
+      </div>
     </div>
   );
 }

--- a/packages/web/src/PerformanceTab.tsx
+++ b/packages/web/src/PerformanceTab.tsx
@@ -100,7 +100,6 @@ export function PerformanceTab({
       {/* CPU 概要(總用量 + per-thread 框框,每個執行緒各自帶折線圖+Y 軸) */}
       <CpuOverview
         cpuPercent={cpuPercent}
-        cores={cores}
         perCore={perCore}
         perCoreScope={perCoreScope}
         history={history}
@@ -204,22 +203,19 @@ export function PerformanceTab({
   );
 }
 
-/** CPU 概要圖卡:總用量數字 + per-thread 框框(每個邏輯處理器一格,各自帶折線圖+XY 軸)。 */
+/** CPU 概要圖卡:總用量數字 + per-thread 框框(純折線圖+Y 軸,不標任何文字)。 */
 function CpuOverview({
   cpuPercent,
-  cores,
   perCore,
   perCoreScope,
   history,
 }: {
   cpuPercent: number | null;
-  cores: number;
   perCore: (number | null)[] | null;
   perCoreScope: "system" | "container" | null;
   history: Sample[];
 }) {
   const scopeLabel = perCoreScope === "system" ? t("系統全執行緒") : perCoreScope === "container" ? t("伺服器專屬") : null;
-  const threadCount = perCore?.length ?? cores;
   const hasPerCore = perCore != null && perCore.length > 0;
 
   return (
@@ -232,20 +228,15 @@ function CpuOverview({
           <span className="text-2xl font-extrabold">{cpuPercent == null ? "—" : `${cpuPercent.toFixed(0)}%`}</span>
           <span className="text-xs text-ink-muted">{t("佔總算力")}</span>
         </div>
-        <span className="text-xs text-ink-muted">
-          {t("{n} 執行緒", { n: threadCount })}
-          {scopeLabel ? ` · ${scopeLabel}` : ""}
-        </span>
+        {scopeLabel && <span className="text-xs text-ink-muted">{scopeLabel}</span>}
       </div>
-      {/* per-thread 框框:每個邏輯處理器一格,各自帶完整折線圖 + Y 軸(0–100%) */}
+      {/* per-thread 框框:每個邏輯處理器一格,純折線圖+Y 軸,框框數量即執行緒數 */}
       {hasPerCore ? (
-        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+        <div className="grid grid-cols-3 gap-1.5 sm:grid-cols-4 lg:grid-cols-6">
           {perCore!.map((_, threadIdx) => {
             const threadValues = history.map((h) => h.perCore?.[threadIdx] ?? null);
             const lastVal = perCore![threadIdx];
-            return (
-              <ThreadChart key={threadIdx} index={threadIdx} values={threadValues} lastVal={lastVal} />
-            );
+            return <ThreadChart key={threadIdx} values={threadValues} lastVal={lastVal} />;
           })}
         </div>
       ) : (
@@ -255,19 +246,18 @@ function CpuOverview({
   );
 }
 
-/** 單一執行緒的框框:標題 + 當前值 + 折線圖(含 Y 軸 0–100% 標示)。 */
-function ThreadChart({ index, values, lastVal }: { index: number; values: Array<number | null>; lastVal: number | null }) {
-  const W = 120;
-  const H = 50;
-  const paddingTop = 4;
-  const paddingBottom = 4;
-  const plotH = H - paddingTop - paddingBottom;
-  // Y 軸:0–100%,固定刻度(0/50/100),讓每個框框比例一致可比較。
+/** 單一執行緒框框:純折線圖 + Y 軸(0–100%),不標任何文字標籤。 */
+function ThreadChart({ values, lastVal }: { values: Array<number | null>; lastVal: number | null }) {
+  const W = 100;
+  const H = 44;
+  const padTop = 2;
+  const padBottom = 2;
+  const plotH = H - padTop - padBottom;
   const yTicks = [0, 50, 100];
   const pts = values.map((v, i) => {
     if (v == null || !Number.isFinite(v)) return null;
     const x = values.length > 1 ? (i / (values.length - 1)) * W : 0;
-    const y = paddingTop + plotH - Math.max(0, Math.min(v / 100, 1)) * plotH;
+    const y = padTop + plotH - Math.max(0, Math.min(v / 100, 1)) * plotH;
     return `${x.toFixed(1)},${y.toFixed(1)}`;
   });
   const segments: string[][] = [];
@@ -277,30 +267,22 @@ function ThreadChart({ index, values, lastVal }: { index: number; values: Array<
     else seg.push(p);
   }
   if (seg.length) segments.push(seg);
-  const lastDisplay = lastVal == null ? "—" : `${lastVal.toFixed(0)}%`;
+  // 高載(>80%)用橘色警示,其餘藍色;hover title 顯示數值。
+  const stroke = lastVal == null ? "#666" : lastVal > 80 ? "#F4A64D" : "#7BB0E8";
 
   return (
-    <div className="rounded-lg border border-line bg-card-soft p-2">
-      <div className="mb-1 flex items-baseline justify-between">
-        <span className="text-xs font-bold text-ink-muted">{t("執行緒 {n}", { n: index })}</span>
-        <span className="text-sm font-extrabold text-pal">{lastDisplay}</span>
+    <div className="flex gap-0.5 rounded-md border border-line bg-card-soft p-1" title={lastVal == null ? undefined : `${lastVal.toFixed(0)}%`}>
+      {/* Y 軸標示(0/50/100) */}
+      <div className="flex shrink-0 flex-col justify-between py-0.5 text-[7px] leading-none text-ink-muted">
+        {yTicks.map((tick) => <span key={tick}>{tick}</span>)}
       </div>
-      <div className="flex gap-1">
-        {/* Y 軸標示 */}
-        <div className="flex shrink-0 flex-col justify-between py-0.5 text-[8px] leading-none text-ink-muted">
-          {yTicks.map((tick) => (
-            <span key={tick}>{tick}</span>
-          ))}
-        </div>
-        {/* 折線圖本體 */}
-        <svg viewBox={`0 0 ${W} ${H}`} className="h-12 flex-1 overflow-visible" preserveAspectRatio="none">
-          {/* Y=50% 參考線 */}
-          <line x1="0" y1={paddingTop + plotH * 0.5} x2={W} y2={paddingTop + plotH * 0.5} stroke="currentColor" strokeWidth="0.5" className="text-line" opacity="0.4" />
-          {segments.map((s, i) => s.length > 1 && (
-            <polyline key={i} points={s.join(" ")} fill="none" stroke="#F4A64D" strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
-          ))}
-        </svg>
-      </div>
+      {/* 折線圖 */}
+      <svg viewBox={`0 0 ${W} ${H}`} className="h-11 flex-1 overflow-visible" preserveAspectRatio="none">
+        <line x1="0" y1={padTop + plotH * 0.5} x2={W} y2={padTop + plotH * 0.5} stroke="currentColor" strokeWidth="0.5" className="text-line" opacity="0.3" />
+        {segments.map((s, i) => s.length > 1 && (
+          <polyline key={i} points={s.join(" ")} fill="none" stroke={stroke} strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
+        ))}
+      </svg>
     </div>
   );
 }

--- a/packages/web/src/PerformanceTab.tsx
+++ b/packages/web/src/PerformanceTab.tsx
@@ -106,7 +106,8 @@ export function PerformanceTab({
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
           <Stat icon={<FiCpu className="size-4" />} label={t("CPU")} value={cpuPercent == null ? "—" : `${cpuPercent.toFixed(0)}%`} sub={t("佔總算力")} />
           <Stat icon={<FiHardDrive className="size-4" />} label={t("記憶體")} value={stats ? fmtBytes(stats.memoryBytes) : "—"} sub={stats && hasFiniteLimit(memoryLimit) ? `／ ${fmtBytes(memoryLimit)}` : undefined} />
-          <Stat icon={<FiZap className="size-4" />} label={t("伺服器 FPS")} value={metrics ? String(metrics.serverfps) : "—"} sub={metrics ? t("影格 {ms} ms", { ms: metrics.serverframetime.toFixed(1) }) : t("需啟用 REST API")} />
+          <Stat icon={<FiZap className="size-4" />} label={t("伺服器 FPS")} value={metrics ? String(metrics.serverfps) : "—"} sub={metrics ? undefined : t("需啟用 REST API")} />
+          {metrics && <Stat icon={<FiActivity className="size-4" />} label={t("影格時間")} value={`${metrics.serverframetime.toFixed(1)} ms`} />}
           <Stat icon={<FiClock className="size-4" />} label={t("運行時間")} value={stats?.uptimeSeconds != null ? fmtDuration(stats.uptimeSeconds) : "—"} sub={stats?.processCount != null ? t("{n} 個行程", { n: stats.processCount }) : undefined} />
           {metrics && <Stat icon={<FiLayers className="size-4" />} label={t("伺服器運行")} value={fmtDuration(metrics.uptime)} />}
         </div>
@@ -152,7 +153,7 @@ export function PerformanceTab({
         {perCore != null && perCore.length > 0 && (
           <div className="border-t border-line pt-3">
             <div className="mb-2 flex items-center justify-between">
-              <span className="text-xs font-bold text-ink-muted">{t("各執行緒")}</span>
+              <span className="text-xs font-bold text-ink-muted">{t("CPU% · 各執行緒")}</span>
               <span className="text-xs text-ink-muted">{perCore.length}</span>
             </div>
             <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
@@ -193,6 +194,9 @@ function ThreadChart({ values, lastVal }: { values: Array<number | null>; lastVa
 
   return (
     <div className="rounded-lg border border-line bg-card-soft p-1.5" title={lastVal == null ? undefined : `${lastVal.toFixed(0)}%`}>
+      <div className="mb-0.5 flex items-baseline justify-between">
+        <span className="text-[8px] font-bold text-ink-muted">{lastVal == null ? "—" : `${lastVal.toFixed(0)}%`}</span>
+      </div>
       <svg viewBox={`0 0 ${W} ${H}`} className="h-12 w-full" preserveAspectRatio="none">
         {segments.some((s) => s.length > 1) && (
           <>

--- a/packages/web/src/PerformanceTab.tsx
+++ b/packages/web/src/PerformanceTab.tsx
@@ -13,6 +13,7 @@ interface Sample {
   perCore: (number | null)[] | null; // per-core 使用率(0–100);null = backend 不支援或首筆
   memPct: number | null;
   fps: number | null;
+  frametime: number | null; // 伺服器影格時間(ms)
 }
 
 /**
@@ -56,6 +57,7 @@ export function PerformanceTab({
         liveMiss.current = l.metrics ? 0 : liveMiss.current + 1;
       }
       const fps = l?.metrics?.serverfps ?? null;
+      const frametime = l?.metrics?.serverframetime ?? null;
       if (s) {
         const cpuPercent = knownCpuSample(s.cpuPercent) ? s.cpuPercent : null;
         setHistory((prev) =>
@@ -68,6 +70,7 @@ export function PerformanceTab({
                 ? clampRatio(s.memoryBytes / s.memoryLimitBytes)
                 : null,
               fps,
+              frametime,
             },
           ].slice(-HISTORY),
         );
@@ -102,14 +105,22 @@ export function PerformanceTab({
         <h3 className="inline-flex items-center gap-2 text-sm font-extrabold">
           <FiActivity className="size-4 text-pal" /> {t("即時數值")}
         </h3>
+        {/* 第一行:CPU / 記憶體 / 伺服器運行時間 */}
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
           <Stat icon={<FiCpu className="size-4" />} label={t("CPU")} value={cpuPercent == null ? "—" : `${cpuPercent.toFixed(0)}%`} />
           <Stat icon={<FiHardDrive className="size-4" />} label={t("記憶體")} value={stats ? (hasFiniteLimit(memoryLimit) ? `${fmtBytes(stats.memoryBytes)} / ${fmtBytes(memoryLimit)}` : fmtBytes(stats.memoryBytes)) : "—"} />
-          <Stat icon={<FiZap className="size-4" />} label={t("伺服器 FPS")} value={metrics ? String(metrics.serverfps) : "—"} sub={metrics ? undefined : t("需啟用 REST API")} />
-          {metrics && <Stat icon={<FiActivity className="size-4" />} label={t("影格時間")} value={`${metrics.serverframetime.toFixed(1)} ms`} />}
-          <Stat icon={<FiClock className="size-4" />} label={t("運行時間")} value={stats?.uptimeSeconds != null ? fmtDuration(stats.uptimeSeconds) : "—"} />
-          {metrics && <Stat icon={<FiLayers className="size-4" />} label={t("伺服器運行")} value={fmtDuration(metrics.uptime)} />}
+          {metrics && <Stat icon={<FiClock className="size-4" />} label={t("伺服器運行時間")} value={fmtDuration(metrics.uptime)} />}
         </div>
+        {/* 第二行:伺服器 FPS / 影格時間 / 遊戲時間(需 REST API) */}
+        {metrics ? (
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+            <Stat icon={<FiZap className="size-4" />} label={t("伺服器 FPS")} value={String(metrics.serverfps)} />
+            <Stat icon={<FiActivity className="size-4" />} label={t("影格時間")} value={`${metrics.serverframetime.toFixed(1)} ms`} />
+            <Stat icon={<FiLayers className="size-4" />} label={t("遊戲時間")} value={t("{n} 天", { n: metrics.days })} />
+          </div>
+        ) : (
+          <p className="text-xs text-ink-muted">{t("伺服器 FPS / 影格時間 / 遊戲時間需啟用 REST API")}</p>
+        )}
       </div>
 
       {/* ② 資源用量容器 — Meter 進度條 */}
@@ -158,11 +169,14 @@ export function PerformanceTab({
             </div>
           </div>
         )}
-        {/* 記憶體 + FPS 共享一行 */}
-        <div className="grid gap-4 sm:grid-cols-2">
+        {/* 記憶體 / FPS / 影格時間 三格自適應 */}
+        <div className="grid gap-4 sm:grid-cols-3">
           <Trend title={t("記憶體使用率")} unit="%" color="#7BB0E8" values={history.map((h) => (h.memPct == null ? null : h.memPct * 100))} max={100} />
           {metrics && (
             <Trend title={t("伺服器 FPS")} unit="" color="#8FCf8F" values={history.map((h) => h.fps)} max={Math.max(60, ...history.flatMap((h) => (h.fps == null ? [] : [h.fps])))} />
+          )}
+          {metrics && (
+            <Trend title={t("影格時間")} unit="ms" color="#C4A8E8" values={history.map((h) => h.frametime)} max={Math.max(33, ...history.flatMap((h) => (h.frametime == null ? [] : [h.frametime])))} />
           )}
         </div>
         {history.length < 2 && <p className="text-xs text-ink-muted">{t("收集資料中,稍待幾秒走勢就會出現。")}</p>}

--- a/packages/web/src/PerformanceTab.tsx
+++ b/packages/web/src/PerformanceTab.tsx
@@ -105,22 +105,19 @@ export function PerformanceTab({
         <h3 className="inline-flex items-center gap-2 text-sm font-extrabold">
           <FiActivity className="size-4 text-pal" /> {t("即時數值")}
         </h3>
-        {/* 第一行:CPU / 記憶體 / 伺服器運行時間 */}
+        {/* 第一行:CPU / 遊戲時間 / 伺服器運行時間 */}
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
           <Stat icon={<FiCpu className="size-4" />} label={t("CPU")} value={cpuPercent == null ? "—" : `${cpuPercent.toFixed(0)}%`} />
-          <Stat icon={<FiHardDrive className="size-4" />} label={t("記憶體")} value={stats ? (hasFiniteLimit(memoryLimit) ? `${fmtBytes(stats.memoryBytes)} / ${fmtBytes(memoryLimit)}` : fmtBytes(stats.memoryBytes)) : "—"} />
-          {metrics && <Stat icon={<FiClock className="size-4" />} label={t("伺服器運行時間")} value={fmtDuration(metrics.uptime)} />}
+          <Stat icon={<FiLayers className="size-4" />} label={t("遊戲時間")} value={metrics ? t("{n} 天", { n: metrics.days }) : "—"} />
+          <Stat icon={<FiClock className="size-4" />} label={t("伺服器運行時間")} value={metrics ? fmtDuration(metrics.uptime) : "—"} />
         </div>
-        {/* 第二行:伺服器 FPS / 影格時間 / 遊戲時間(需 REST API) */}
-        {metrics ? (
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-            <Stat icon={<FiZap className="size-4" />} label={t("伺服器 FPS")} value={String(metrics.serverfps)} />
-            <Stat icon={<FiActivity className="size-4" />} label={t("影格時間")} value={`${metrics.serverframetime.toFixed(1)} ms`} />
-            <Stat icon={<FiLayers className="size-4" />} label={t("遊戲時間")} value={t("{n} 天", { n: metrics.days })} />
-          </div>
-        ) : (
-          <p className="text-xs text-ink-muted">{t("伺服器 FPS / 影格時間 / 遊戲時間需啟用 REST API")}</p>
-        )}
+        {/* 第二行:記憶體 / 伺服器 FPS / 影格時間 */}
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          <Stat icon={<FiHardDrive className="size-4" />} label={t("記憶體")} value={stats ? (hasFiniteLimit(memoryLimit) ? `${fmtBytes(stats.memoryBytes)} / ${fmtBytes(memoryLimit)}` : fmtBytes(stats.memoryBytes)) : "—"} />
+          <Stat icon={<FiZap className="size-4" />} label={t("伺服器 FPS")} value={metrics ? String(metrics.serverfps) : "—"} />
+          <Stat icon={<FiActivity className="size-4" />} label={t("影格時間")} value={metrics ? `${metrics.serverframetime.toFixed(1)} ms` : "—"} />
+        </div>
+        {!metrics && <p className="text-xs text-ink-muted">{t("伺服器 FPS / 影格時間 / 遊戲時間需啟用 REST API")}</p>}
       </div>
 
       {/* ② 資源用量容器 — Meter 進度條 */}
@@ -131,7 +128,7 @@ export function PerformanceTab({
         {stats ? (
           <>
             <Meter
-              label={t("CPU（佔總算力）")}
+              label={t("CPU")}
               text={cpuPercent == null ? "—" : `${cpuPercent.toFixed(1)}%`}
               ratio={cpuPercent == null ? null : clampRatio(cpuPercent / 100)}
             />


### PR DESCRIPTION
Closes #63

## 概要

重新設計效能分析分頁的 CPU 顯示：後端三種 backend 新增 per-thread CPU 採集並統一 cpuPercent 語意；前端重組為三個職責容器與 per-thread 折線圖框框，並修正即時數值的閱讀順序。

## 已實現的功能

### 後端：per-thread 採集與正規化

- InstanceStats 新增 perCore（每執行緒使用率 0–100）與 perCoreScope（system/container）欄位。
- native backend 使用 os.cpus() 計算各核心差分，標示為 system。
- docker backend 使用 percpu_usage 與 precpu_usage 差分，標示為 container。
- k8s backend 使用 cpuacct.usage_percpu，並在需要時 fallback 至 /proc/stat 的 cpuN 行。
- 三種 backend 的 cpuPercent 統一為「佔總算力 0–100%」；native 與 k8s 依核心數正規化，docker 移除核心數乘數。

### 前端：三容器 UI 重設計

效能分頁重組為三個職責容器：

1. **即時數值**：第一行為 CPU、遊戲時間、伺服器運行時間；第二行為記憶體、伺服器 FPS、影格時間。REST metrics 不可用時保留欄位並顯示 —。
2. **資源用量**：CPU 與記憶體 Meter；CPU 標籤不再顯示「佔總算力」字眼。
3. **即時走勢**：CPU Trend（整行）、per-thread 框框，以及記憶體、FPS、影格時間 Trend。

per-thread 框框每個邏輯處理器一格，使用 area fill 與 polyline 對齊 Trend 視覺，高載（>80%）使用橘色警示。

## 測試與驗證

- 本地 pnpm typecheck 通過。
- GitHub Actions build 通過（PR head c877276）。
- native-stats.test.ts 覆蓋 per-core 首筆 null、半載、多核獨立與無有效差分等情境。
- 原始碼靜態驗證確認即時數值順序與 REST 缺資料時的 — 佔位；本次未執行瀏覽器視覺驗收。

## 相容性與行為邊界

- cpuPercent 從「單核基準可破百」改為「佔總算力 0–100%」；前端不再重複除以核心數。
- per-core 語意依 backend 而異：native 為系統全核，docker 為容器專屬，k8s 依 cgroup 版本決定；perCoreScope 會標示範圍。
- k8s cgroup v2 沒有 per-core cgroup 資料時，fallback 至 host 的 /proc/stat，因此語意為 system。
- perCore 首筆需要兩次取樣才能計算，前端會顯示 —。
- 若 docker backend 未來需要依 CPU quota 正規化，需另讀 container inspect 的 CpuQuota/CpuPeriod。

## 後續開發注意事項

目前保留 per-thread scope 差異與 docker CPU quota 正規化作為後續可獨立處理的行為邊界。