### PR TITLE
fix: 離線玩家最後上線改用 lastSeen

### DIFF
--- a/packages/web/src/ui.tsx
+++ b/packages/web/src/ui.tsx
@@ -79,15 +79,16 @@ export const inputCls =
 export const labelCls = "flex flex-col gap-1.5 text-left text-[13px] font-bold text-ink-muted";
 export const errorCls = "rounded-xl bg-berry/10 px-3 py-2 text-[13px] font-bold text-berry";
 
-/** 上線時間統一顯示(絕對日期):SAV daysAgo 推算(整日精度)/ agent lastSeen / 空。荒廢篩選另用天數。 */
+/** 上線時間統一顯示。優先序:agent lastSeen(精確日期+時間,即真實最後上線) >
+ *  SAV daysAgo(整日精度,只顯示日期,避免時分秒淪為「現在」隨秒跳動) > 空。荒廢篩選另用天數。 */
 export const fmtLastOnline = (
   daysAgo: number | null | undefined,
   lastSeen?: string,
 ): string =>
-  daysAgo != null
-    ? new Date(Date.now() - daysAgo * 86_400_000).toLocaleString()
-    : lastSeen
-      ? new Date(lastSeen).toLocaleString()
+  lastSeen
+    ? new Date(lastSeen).toLocaleString()
+    : daysAgo != null
+      ? new Date(Date.now() - daysAgo * 86_400_000).toLocaleDateString()
       : "";
 
 /** 下拉選單:隱藏各瀏覽器不一致的原生箭頭,改用自繪 chevron(和語言切換一致)。 */


### PR DESCRIPTION
Closes #70

## 概要

修復離線玩家「最後上線」時間被顯示成現在時間並隨秒跳動的問題。

## 已實現

`fmtLastOnline`(`packages/web/src/ui.tsx`)顯示優先序改為:

1. **`lastSeen` 優先**(agent 觀測玩家在線的精確時刻 = 真實最後上線):顯示完整日期+時間。
2. **`daysAgo` 降級**(僅無 `lastSeen` 的玩家,如存檔有但 agent 未觀測者):顯示日曆日期(整日精度),不再以 `toLocaleString` 印出時分秒(避免時分秒淪為「現在時間」隨秒跳動)。

此優先序恢復了「上線資訊統一日期語意並以 SAV 為權威」改動之前、離線玩家以 `lastSeen` 顯示的正確行為。

## 驗證

- `pnpm typecheck`(shared / web / agent / discord-bot / stats 全通過)。
- 實機驗證(連接運行中的伺服器):known 離線玩家「最後上線」顯示精確時刻,與「上下線紀錄」該玩家最後離線時間一致;連續觀察欄位穩定、不隨秒變;無 agent 觀測紀錄的玩家顯示日級日期。

## 相容性與行為邊界

- 只改 `fmtLastOnline` 單一函式(UI-only),不動 agent / shared。
- 4 個使用點(`PlayersTab` / `PlayerDetailModal` / `GuildDetailModal` / `SavesTab`)行為一致:有 `lastSeen` 顯示精確、僅 `daysAgo` 顯示日級。
- 離線玩家最後上線不再隨秒跳動。

## 後續開發注意

- 無 agent 觀測紀錄的玩家(純存檔來源)顯示日級日期為目前精度上限(存檔的 `last_online_real_time` 為相對基準 ticks,無法換算絕對時間)。
