### PR TITLE
fix(version): installedManifests 應取最新 mtime,而非 readdir 掃到的最後一筆

### DIFF
--- a/packages/agent/src/version.test.ts
+++ b/packages/agent/src/version.test.ts
@@ -1,0 +1,61 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { installedManifests } from "./version.js";
+
+function makeDepotDownloaderDir(files: Array<{ name: string; mtimeMs: number }>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "palserver-version-test-"));
+  const dir = path.join(root, ".DepotDownloader");
+  fs.mkdirSync(dir);
+  for (const { name, mtimeMs } of files) {
+    fs.writeFileSync(path.join(dir, name), "");
+    const time = mtimeMs / 1000;
+    fs.utimesSync(path.join(dir, name), time, time);
+  }
+  return root;
+}
+
+test("installedManifests: picks the newest manifest by mtime, not readdir order", () => {
+  // Same depot (2394011), three manifests left behind by successive updates.
+  // Filenames are deliberately out of chronological order alphabetically:
+  // the oldest id starts with "9", which sorts after ids starting with "4"/"5",
+  // so a naive "last one wins while iterating readdirSync()" pick lands on
+  // the stale manifest even though it was written first.
+  const root = makeDepotDownloaderDir([
+    { name: "2394011_959286178212427927.manifest", mtimeMs: Date.parse("2026-07-18T15:00:00Z") },
+    { name: "2394011_5495152179854198969.manifest", mtimeMs: Date.parse("2026-07-30T01:27:00Z") },
+    { name: "2394011_4660214116639624645.manifest", mtimeMs: Date.parse("2026-07-30T13:38:00Z") },
+  ]);
+
+  assert.deepEqual(installedManifests(root), { "2394011": "4660214116639624645" });
+});
+
+test("installedManifests: ignores non-manifest files and ok with an empty dir", () => {
+  const root = makeDepotDownloaderDir([
+    { name: "2394011_111.manifest", mtimeMs: Date.parse("2026-07-18T15:00:00Z") },
+    { name: "2394011_111.manifest.sha", mtimeMs: Date.parse("2026-07-18T15:00:00Z") },
+    { name: "depot.config", mtimeMs: Date.parse("2026-07-18T15:00:00Z") },
+  ]);
+
+  assert.deepEqual(installedManifests(root), { "2394011": "111" });
+});
+
+test("installedManifests: missing .DepotDownloader dir (adopted install) returns {}", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "palserver-version-test-"));
+  assert.deepEqual(installedManifests(root), {});
+});
+
+test("installedManifests: tracks the newest manifest independently per depot", () => {
+  const root = makeDepotDownloaderDir([
+    { name: "1004_5612541580377302256.manifest", mtimeMs: Date.parse("2026-07-18T15:00:00Z") },
+    { name: "2394011_959286178212427927.manifest", mtimeMs: Date.parse("2026-07-18T15:00:00Z") },
+    { name: "2394011_4660214116639624645.manifest", mtimeMs: Date.parse("2026-07-30T13:38:00Z") },
+  ]);
+
+  assert.deepEqual(installedManifests(root), {
+    "1004": "5612541580377302256",
+    "2394011": "4660214116639624645",
+  });
+});

--- a/packages/agent/src/version.ts
+++ b/packages/agent/src/version.ts
@@ -94,14 +94,40 @@ export async function fetchLatest(force = false): Promise<LatestInfo | null> {
   }
 }
 
-/** depotId → manifest id, as installed on disk. */
+/**
+ * depotId → manifest id, as installed on disk.
+ *
+ * DepotDownloader never deletes a depot's old `<depotId>_<manifestId>.manifest`
+ * file when it patches to a new one — it just adds another one alongside it,
+ * so a depot that's been updated a few times ends up with several manifest
+ * files. `fs.readdirSync` order is not guaranteed to be chronological (in
+ * practice it comes back roughly alphabetical), so naively taking "whichever
+ * one we saw last per depotId" can and does land on a stale manifest — e.g.
+ * an old id starting with "9" sorts after a current one starting with "4",
+ * even though the "4" one is what's actually installed. That made
+ * `updateAvailable` report true forever, even right after a successful
+ * update. Picking the file with the newest mtime instead reflects what
+ * DepotDownloader most recently wrote, which is what's actually installed.
+ */
 export function installedManifests(root: string): Record<string, string> {
   const dir = path.join(root, ".DepotDownloader");
   const result: Record<string, string> = {};
+  const mtimes: Record<string, number> = {};
   try {
     for (const name of fs.readdirSync(dir)) {
       const match = /^(\d+)_(\d+)\.manifest$/.exec(name);
-      if (match) result[match[1]] = match[2];
+      if (!match) continue;
+      const [, depotId, manifestId] = match;
+      let mtimeMs: number;
+      try {
+        mtimeMs = fs.statSync(path.join(dir, name)).mtimeMs;
+      } catch {
+        continue;
+      }
+      if (!(depotId in result) || mtimeMs > mtimes[depotId]) {
+        result[depotId] = manifestId;
+        mtimes[depotId] = mtimeMs;
+      }
     }
   } catch {
     /* not an agent-managed install (e.g. adopted from Steam) */


### PR DESCRIPTION
## 問題

伺服器明明已經更新到最新版本，GUI 卻一直顯示「有新版本可更新」（`updateAvailable: true` 永遠是 true，即使剛更新完）。

## 根因

`installedManifests()`（`packages/agent/src/version.ts`）用來判斷「這個 depot 目前裝的是哪個 manifest」，方法是掃 `.DepotDownloader/` 目錄下所有 `<depotId>_<manifestId>.manifest` 檔案，同一個 `depotId` 出現多次時「後蓋前」。

但 DepotDownloader 更新一個 depot 到新 manifest 時**不會刪除舊的 manifest 檔案**，只會在旁邊多留一份。於是一個更新過幾次的 depot，目錄下會同時存在好幾個舊 manifest 檔案。

`fs.readdirSync()` 回傳的順序**不保證跟寫入時間一致**，實務上接近字母序。如果舊 manifest id 剛好字首比新的大（例如舊的是 `9` 開頭、新的是 `4` 開頭），字母序會把舊的排在後面，導致「後蓋前」邏輯把舊 manifest id 當成目前安裝版本回報出去，跟 Steam 最新 manifest 一比對，就永遠判定有更新可用——即使實際檔案早就是最新版了。

這是我們自己的伺服器上實測到的真實案例（同一個 depot `2394011` 底下留了三份不同時期的 manifest，被比對成永遠 stale）。

## 修法

改成逐檔比對 `mtimeMs`，同一個 `depotId` 只保留寫入時間最新的那筆，準確反映 DepotDownloader 最後一次實際寫入的 manifest。

## 測試

新增 `packages/agent/src/version.test.ts`，用本專案自己遇到的真實 manifest id 重現這個情境並驗證修復：

```
✔ installedManifests: picks the newest manifest by mtime, not readdir order
✔ installedManifests: ignores non-manifest files and ok with an empty dir
✔ installedManifests: missing .DepotDownloader dir (adopted install) returns {}
✔ installedManifests: tracks the newest manifest independently per depot
```

`pnpm typecheck`、`pnpm build`、`node --import tsx --test src/*.test.ts`（agent 套件全部 121 個測試）皆通過。