### PR TITLE
feat(files): add authenticated downloads

### DIFF
--- a/packages/agent/src/files.ts
+++ b/packages/agent/src/files.ts
@@ -94,6 +94,14 @@ export function readFile(root: string, relPath: string): FileContent {
   return { path: relPath, content: fs.readFileSync(file, "utf8") };
 }
 
+/** Resolve a regular file for binary download without reading it into memory. */
+export function downloadFilePath(root: string, relPath: string): string {
+  const file = resolveInRoot(root, relPath);
+  const stat = fs.statSync(file, { throwIfNoEntry: false });
+  if (!stat?.isFile()) throw badRequest("檔案不存在", 404);
+  return file;
+}
+
 export function writeFile(root: string, relPath: string, content: string): void {
   const file = resolveInRoot(root, relPath);
   if (!isTextFile(path.basename(file))) throw badRequest("只能編輯文字檔");

--- a/packages/agent/src/k8s-file-browser.ts
+++ b/packages/agent/src/k8s-file-browser.ts
@@ -3,6 +3,7 @@ import type { DirEntry, FileContent } from "@palserver/shared";
 import type { InstanceRecord } from "./store.js";
 import {
   deletePathInPod,
+  downloadFileInPod,
   execInPod,
   listDirInPod,
   makeDirInPod,
@@ -70,6 +71,14 @@ export async function readFileInPodBrowser(rec: InstanceRecord, relPath: string)
   const stat = await statInPod(rec, full);
   if (stat.size > MAX_EDIT_BYTES) throw badRequest("檔案過大,無法在編輯器中開啟");
   return { path: relPath, content: await readFileInPod(rec, relPath) };
+}
+
+/** Download raw file bytes after applying the same Pod-root path guard. */
+export async function downloadFileInPodBrowser(rec: InstanceRecord, relPath: string): Promise<Buffer> {
+  const full = assertRelative(relPath, false);
+  const isFile = await execInPod(rec, ["test", "-f", full]).then(() => true).catch(() => false);
+  if (!isFile) throw badRequest("檔案不存在", 404);
+  return downloadFileInPod(rec, relPath);
 }
 
 export async function writeFileInPodBrowser(rec: InstanceRecord, relPath: string, content: string): Promise<void> {

--- a/packages/agent/src/routes.ts
+++ b/packages/agent/src/routes.ts
@@ -72,6 +72,7 @@ import { saveWorld } from "./world-save.js";
 import * as files from "./files.js";
 import {
   deletePathInPodBrowser,
+  downloadFileInPodBrowser,
   listDirInPodBrowser,
   makeDirInPodBrowser,
   readFileInPodBrowser,
@@ -2744,6 +2745,29 @@ export function registerRoutes(
     const { path: rel } = PathQuery.parse(req.query);
     if (rec.backend === "k8s") return readFileInPodBrowser(rec, rel);
     return files.readFile(files.fileRoot(rec, ctxOf(rec)), rel);
+  });
+
+  /** Download one file from the instance file browser without buffering native files in memory. */
+  app.get("/api/instances/:id/files/download", async (req, reply) => {
+    const rec = getOr404((req.params as { id: string }).id);
+    const { path: rel } = z.object({ path: z.string().min(1).max(500) }).parse(req.query);
+    const downloadHeaders = (filename: string, size: number) => {
+      const asciiFilename = filename.replace(/[\\\\\"\r\n]/g, "_").replace(/[^\x20-\x7e]/g, "_") || "download";
+      const encodedFilename = encodeURIComponent(filename).replace(/[!'()*]/g, (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`);
+      reply.header("content-type", "application/octet-stream");
+      reply.header("content-disposition", `attachment; filename="${asciiFilename}"; filename*=UTF-8''${encodedFilename}`);
+      reply.header("content-length", String(size));
+      reply.header("x-content-type-options", "nosniff");
+    };
+    if (rec.backend === "k8s") {
+      const content = await downloadFileInPodBrowser(rec, rel);
+      downloadHeaders(path.posix.basename(rel), content.length);
+      return content;
+    }
+    const file = files.downloadFilePath(files.fileRoot(rec, ctxOf(rec)), rel);
+    const stat = await fs.promises.stat(file);
+    downloadHeaders(path.basename(file), stat.size);
+    return fs.createReadStream(file);
   });
 
   app.put("/api/instances/:id/files/content", async (req) => {

--- a/packages/web/src/FileManager.tsx
+++ b/packages/web/src/FileManager.tsx
@@ -6,6 +6,7 @@ import {
   FiTrash2,
   FiFolderPlus,
   FiEdit2,
+  FiDownload,
   FiChevronRight,
   FiRefreshCw,
 } from "react-icons/fi";
@@ -98,6 +99,27 @@ export function FileManager({
     }
   };
 
+  const download = async (entry: DirEntry) => {
+    if (entry.isDir) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const blob = await client.downloadFile(instanceId, joinPath(dir, entry.name));
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = entry.name;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 60_000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const segments = dir ? dir.split("/") : [];
 
   return (
@@ -174,6 +196,16 @@ export function FileManager({
                   {entry.isDir ? "—" : fmtSize(entry.size)}
                 </span>
                 <div className="flex shrink-0 gap-1.5">
+                  {!entry.isDir && (
+                    <button
+                      className="rounded-full border-[1.5px] border-line px-3 py-1 text-xs font-bold text-ink transition hover:border-pal"
+                      onClick={() => download(entry)}
+                      disabled={busy}
+                      title={t("下載")}
+                    >
+                      <FiDownload className="inline size-3.5" /> {t("下載")}
+                    </button>
+                  )}
                   {entry.editable && (
                     <button
                       className="rounded-full border-[1.5px] border-line px-3 py-1 text-xs font-bold text-ink transition hover:border-pal"

--- a/packages/web/src/api.ts
+++ b/packages/web/src/api.ts
@@ -1059,6 +1059,21 @@ export class AgentClient {
     return this.request(`/api/instances/${id}/files/content?path=${encodeURIComponent(path)}`);
   }
 
+  async downloadFile(id: string, path: string): Promise<Blob> {
+    const res = await fetch(`${this.conn.url}/api/instances/${id}/files/download?path=${encodeURIComponent(path)}`, {
+      headers: { Authorization: `Bearer ${this.conn.token}` },
+    });
+    if (res.status === 401) {
+      this.onUnauthorized?.();
+      throw new Error("unauthorized");
+    }
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({ error: res.statusText }));
+      throw new Error((body as { error?: string }).error ?? `HTTP ${res.status}`);
+    }
+    return res.blob();
+  }
+
   writeFile(id: string, path: string, content: string): Promise<{ saved: string }> {
     return this.request(`/api/instances/${id}/files/content`, {
       method: "PUT",


### PR DESCRIPTION
## 背景

目前「文件管理」已支持浏览、编辑、上传、创建文件夹与删除，但无法将服务器中的存档、配置或模组文件下载到本地。对于存档迁移前备份、排查配置与取回日志，管理员仍需额外使用 SSH/SFTP，和现有 GUI 的文件管理体验不一致。

## 本次改动

- 在文件管理器的每个普通文件行新增「下载」按钮；目录不显示该按钮。
- 新增受认证保护的接口：`GET /api/instances/:id/files/download?path=...`。
- 前端通过带 `Authorization: Bearer <token>` 请求头的 `fetch` 获取 Blob，再触发浏览器下载。
  - 不把 agent token 拼接进下载 URL，避免 token 出现在浏览器历史、代理日志或复制出的链接中。
  - 下载失败会沿用文件管理器现有的错误提示区域。
- 原生与 Docker 后端使用 `fs.createReadStream` 返回文件，避免将大型 `.sav`、`.pak` 或日志完整读入 agent 内存。
- K8s 后端新增对应下载路径，并使用与现有 Pod 文件浏览器一致的根目录与普通文件校验。

## 安全与边界

- 下载路由沿用全局 API Bearer 认证；未授权请求会被拒绝。
- 原生 / Docker 路径继续通过现有 `resolveInRoot` 校验，拒绝绝对路径、`..` 逃逸及指向根目录外的符号链接。
- K8s 路径继续通过 `resolvePodPath` / `assertRelative` 约束在 `/palworld` 下。
- 仅允许下载普通文件；目录和不存在的路径均返回错误。
- 响应设置 `Content-Disposition: attachment`、`Content-Length` 与 `X-Content-Type-Options: nosniff`。文件名同时提供 ASCII 回退和 UTF-8 编码参数，以兼容中文文件名及防止响应头注入。

## 验证

- 已运行 `git diff --check`。
- 已对 5 个修改过的 TypeScript/TSX 文件执行 TypeScript 语法转换检查。
- 在实际 native agent 环境中测试受认证的 `Level.sav` 下载：
  - HTTP 状态：`200`
  - 源文件与下载文件大小：均为 `3,040,349` 字节
  - SHA-256：两者一致（`d68424ae1c3c753e6b183204be76c958c54c3c652ac9d5a3ec2bc53135350db3`）
- 未带认证令牌访问同一路由时返回 `401`。

## 兼容性

本改动不改变现有上传、编辑、删除、备份导出或服务器启动逻辑。现有文件浏览 API 与接口保持不变；下载能力为新增的独立路由。